### PR TITLE
Support format args logging

### DIFF
--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -170,11 +170,29 @@ class LogBar(logging.Logger):
         self.error = self.error_cls(logger=self)
         self.critical = self.critical_cls(logger=self)
 
+    def _format_message(self, msg, args):
+        """Format a log message similarly to the stdlib logging module."""
+        if not args:
+            return str(msg)
+
+        fmt_args = args
+
+        if len(args) == 1 and isinstance(args[0], dict):
+            fmt_args = args[0]
+
+        if isinstance(msg, str):
+            try:
+                return msg % fmt_args
+            except (TypeError, ValueError):
+                pass
+
+        return str(msg)
+
     def _process(self, level: LEVEL, msg, *args, **kwargs):
         from logbar.progress import ProgressBar
 
         columns, _ = terminal_size()
-        str_msg = str(msg)
+        str_msg = self._format_message(msg, args)
 
         if columns > 0:
             str_msg += " " * (columns - LEVEL_MAX_LENGTH - 2 - len(str_msg))  # -2 for cursor + space between LEVEL and msg

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -9,6 +9,12 @@ log = LogBar.shared(override_logger=True)
 
 class TestProgressBar(unittest.TestCase):
 
+    def capture_log(self, callable_, *args, **kwargs):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            callable_(*args, **kwargs)
+        return buffer.getvalue()
+
     def test_log_simple(self):
         log.info("hello info")
 
@@ -24,9 +30,24 @@ class TestProgressBar(unittest.TestCase):
         log.critical("hello critical")
 
     def test_percent_formatting(self):
-        buffer = io.StringIO()
-        with redirect_stdout(buffer):
-            log.info("%d", 123)
-
-        output = buffer.getvalue()
+        output = self.capture_log(log.info, "%d", 123)
         self.assertIn("123", output)
+
+    def test_percent_formatting_multiple_args(self):
+        cases = [
+            ("Numbers: %d %d %d", (1, 2, 3)),
+            ("Signed and padded: %+d %05d", (42, 7)),
+            ("Floats: %.2f %.1f", (3.14159, 2.5)),
+            ("Mapping: %(name)s => %(value)04d", ({"name": "counter", "value": 12},)),
+            ("Literal percent %% and value %d%%", (88,)),
+        ]
+
+        for fmt, args in cases:
+            output = self.capture_log(log.info, fmt, *args)
+
+            fmt_args = args
+            if len(args) == 1 and isinstance(args[0], dict):
+                fmt_args = args[0]
+
+            expected = fmt % fmt_args
+            self.assertIn(expected, output)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,11 @@
+import io
 import unittest
+from contextlib import redirect_stdout
 
 from logbar import LogBar
 
 log = LogBar.shared(override_logger=True)
+
 
 class TestProgressBar(unittest.TestCase):
 
@@ -19,3 +22,11 @@ class TestProgressBar(unittest.TestCase):
         log.warn("hello warn")
         log.error("hello error")
         log.critical("hello critical")
+
+    def test_percent_formatting(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            log.info("%d", 123)
+
+        output = buffer.getvalue()
+        self.assertIn("123", output)


### PR DESCRIPTION
## Summary
- add formatting support that mirrors logging's percent-style interpolation before printing
- cover the new behavior with a regression test that ensures inline arguments render correctly

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0b2756888330840636374abe7b93