### PR TITLE
Auto-disable progress bars/animations in headless/AI-agent/Codex/Jupyter/CI shells

### DIFF
--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -28,6 +28,8 @@ last_rendered_length = 0
 _STATE_LOCK = threading.RLock()
 _RENDER_LOCK = threading.RLock()
 _EXTERNAL_TERMINAL_HANDOFF_HOOKS_INSTALLED = False
+_HEADLESS_LOG_EMITTED = False
+_HEADLESS_LOG_LOCK = threading.RLock()
 
 def _stdout_stream():
     """Return the stdout stream wrapper used by all renderer writes."""
@@ -113,6 +115,38 @@ def _running_in_notebook_environment() -> bool:
     shell = getattr(ip, "__class__", None)
     shell_name = getattr(shell, "__name__", "")
     return shell_name == "ZMQInteractiveShell"
+
+
+def _log_headless_state_once(backend_state: Optional[RenderBackendState] = None) -> None:
+    """Emit a single INFO log when LogBar is running in a headless environment."""
+
+    global _HEADLESS_LOG_EMITTED, logger
+
+    with _HEADLESS_LOG_LOCK:
+        if _HEADLESS_LOG_EMITTED:
+            return
+        _HEADLESS_LOG_EMITTED = True
+
+    if backend_state is None:
+        try:
+            backend_state = _current_render_backend_state()
+        except Exception:
+            return
+
+    if not backend_state.headless:
+        return
+
+    log = logger
+    if log is None:
+        try:
+            log = LogBar.shared()
+        except Exception:
+            return
+
+    log.info(
+        "LogBar: headless/AI-agent/notebook/CI environment detected; "
+        "high-frequency progress bars and animations are disabled."
+    )
 
 
 def _stdout_supports_cursor_movement() -> bool:
@@ -489,6 +523,18 @@ def _clear_progress_stack_locked(
     coordinator_state = _coordinator_state()
     count = coordinator_state._last_drawn_progress_count
     state = backend_state or _current_render_backend_state()
+
+    if state.headless:
+        coordinator_state._last_drawn_progress_count = 0
+        coordinator_state._last_rendered_terminal_size = None
+        coordinator_state._last_rendered_progress_lines = []
+        coordinator_state._cursor_positioned_above_stack = False
+        coordinator_state._cursor_positioned_on_stack_top = False
+        coordinator_state._stack_redraw_invalidated = False
+        if flush_deferred_logs and not for_log_output:
+            _flush_deferred_logs_locked()
+        return
+
     supports_cursor = state.supports_cursor
 
     if not supports_cursor:
@@ -844,6 +890,14 @@ def _render_progress_stack_locked(
 
     coordinator_state = _coordinator_state()
     state = backend_state or _current_render_backend_state(columns_hint)
+
+    if state.headless:
+        bars = _active_progress_bars()
+        with _STATE_LOCK:
+            coordinator_state._dirty_progress_bars.difference_update(bars)
+        _record_progress_activity_locked()
+        return
+
     columns = state.columns
     rows = state.lines
 
@@ -1089,6 +1143,9 @@ def _record_progress_activity() -> None:
 def _should_refresh_in_background(state: RenderBackendState, bars: Sequence["ProgressBar"]) -> bool:
     """Return whether the background worker should wake for current bars."""
 
+    if state.headless:
+        return False
+
     if state.supports_cursor or state.notebook:
         return True
 
@@ -1167,6 +1224,12 @@ def _progress_refresh_worker() -> None:
 
 def _ensure_background_refresh_thread() -> None:
     """Start the shared renderer refresh worker exactly once."""
+
+    try:
+        if _current_render_backend_state().headless:
+            return
+    except Exception:
+        pass
 
     with _STATE_LOCK:
         state = _coordinator_state()
@@ -1286,6 +1349,8 @@ class LogBar(logging.Logger):
                 _print("", end='\n', flush=True)
 
         _ensure_background_refresh_thread()
+
+        _log_headless_state_once()
 
         return shared_logger
 

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -25,6 +25,7 @@ from .logbar import (
     mark_progress_bar_dirty,
     render_lock,
     render_progress_stack,
+    _log_headless_state_once,
 )
 if TYPE_CHECKING:  # pragma: no cover - type hints without runtime import cycle
     from .logbar import LogBar as LogBarType
@@ -496,6 +497,18 @@ class ProgressBar:
         )
         self._last_output_step: Optional[int] = None
 
+        # Auto-detect headless/AI-agent/notebook/CI environments and suppress
+        # high-frequency redraws so logs do not get polluted with terminal
+        # control sequences in remote or non-interactive shells.
+        _backend_state = render_backend_state(
+            stream=sys.stdout,
+            size_provider=terminal_size,
+            notebook=_running_in_notebook_environment(),
+        )
+        self._headless = _backend_state.headless
+        if self._headless:
+            _log_headless_state_once(_backend_state)
+
         self.ui_show_left_steps = True # show [1 of 100] on left side
         self.ui_show_left_steps_offset = 0
 
@@ -808,6 +821,9 @@ class ProgressBar:
         if self._attached:
             return self
 
+        if self._headless:
+            return self
+
         target_logger = logger or self._owner_logger or LogBar.shared()
         self._attached_logger = target_logger
         self._owner_logger = target_logger
@@ -933,6 +949,9 @@ class ProgressBar:
     @_render_locked
     def draw(self, force: bool = False):
         """Render the current progress state either inline or in the stack."""
+
+        if self._headless:
+            return
 
         # Even skipped draws count as activity. This prevents the background
         # refresher from redrawing the same bar immediately and undoing the
@@ -1208,6 +1227,8 @@ class ProgressBar:
         try:
             state = self._render_backend_state(backend_state)
         except Exception:
+            return False
+        if state.headless:
             return False
         if style_enabled is None:
             style_enabled = state.supports_styling

--- a/logbar/terminal.py
+++ b/logbar/terminal.py
@@ -25,6 +25,7 @@ class RenderBackendState:
     supports_cursor: bool
     supports_ansi: bool
     supports_styling: bool
+    headless: bool = False
 
 
 def _stream_terminal_size(stream: Optional[object], fallback: tuple[int, int]) -> Optional[tuple[int, int]]:
@@ -91,6 +92,119 @@ def terminal_size(fallback=(80, 24), stream: Optional[object] = None):
     return (columns, lines)
 
 
+# Environment markers used by AI-agent, remote, or non-interactive runtimes.
+# A match on its own is enough to disable animated/redrawing UI in LogBar.
+_HEADLESS_ENV_VARS = frozenset(
+    [
+        "CI",
+        "CI_NAME",
+        "BUILD_ID",
+        "BUILDKITE",
+        "TEAMCITY_VERSION",
+        "TF_BUILD",
+        "JENKINS_URL",
+        "CIRCLECI",
+        "TRAVIS",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "AGENT",
+        "AI_AGENT",
+        "AGENT_ID",
+        "SMITHERY",
+        "AIDER",
+        "CODEX_HOME",
+        "CODEX_SQLITE_HOME",
+        "CODEX_API_KEY",
+        "CODEX_ACCESS_TOKEN",
+        "CODEX_NON_INTERACTIVE",
+        "DEVIN_OUTPOST_SESSION_ID",
+        "DEVIN_OUTPOST_CONNECT_TOKEN",
+        "DEVIN_OUTPOST_GATEWAY_URL",
+        "DEVIN_REMOTE_AUTH_TOKEN",
+        "DEVIN_REMOTE_STATE_DIR",
+        "DEVIN_PTY_BRIDGE_PORT",
+        "JPY_PARENT_PID",
+        "IPYKERNEL_PARENT_PID",
+        "JUPYTER_SERVER_URI",
+        "KAGGLE_KERNEL_RUN_TYPE",
+        "COLAB_GPU",
+        "COLAB_BACKEND_VERSION",
+    ]
+)
+
+# Environment variable name prefixes that strongly indicate an AI-agent shell.
+_HEADLESS_ENV_PREFIXES = (
+    "DEVIN_",
+    "CODEX_",
+    "SMITHERY_",
+    "AIDER_",
+    "CLAUDE_",
+    "ANTHROPIC_",
+    "COPILOT_",
+    "__COG_",
+)
+
+
+def _is_stream_tty(stream: Optional[object]) -> bool:
+    """Best-effort check whether ``stream`` is connected to a real terminal."""
+
+    target = stream if stream is not None else sys.stdout
+    isatty = getattr(target, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except Exception:
+        return False
+
+
+def _env_flag_enabled(name: str) -> bool:
+    """Return True when ``name`` is set to a non-empty, non-disabling value."""
+
+    value = str(os.environ.get(name, "")).strip().lower()
+    return value not in {"", "0", "false", "off", "no"}
+
+
+def _running_under_pytest() -> bool:
+    """Best-effort detection for pytest-driven terminal sessions."""
+
+    argv0 = str(sys.argv[0]).lower() if sys.argv else ""
+    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in argv0
+
+
+def _is_headless_environment(*, notebook: bool = False) -> bool:
+    """Detect non-interactive, AI-agent, notebook, or CI environments.
+
+    Headless detection is intentionally disabled while LogBar is running under
+    pytest so that the test suite can continue to assert against rendered
+    output. Callers can force redrawing with ``LOGBAR_FORCE_PROGRESS=1`` or
+    disable this heuristic with ``LOGBAR_DISABLE_HEADLESS_DETECTION=1``.
+    """
+
+    if _env_flag_enabled("LOGBAR_FORCE_PROGRESS"):
+        return False
+
+    if _env_flag_enabled("LOGBAR_DISABLE_HEADLESS_DETECTION"):
+        return False
+
+    # Do not disable the UI while the test suite is driving it.
+    if _running_under_pytest():
+        return False
+
+    if notebook:
+        return True
+
+    env_vars = os.environ
+    for key in env_vars:
+        if key in _HEADLESS_ENV_VARS or key.startswith(_HEADLESS_ENV_PREFIXES):
+            return True
+
+    if os.environ.get("TERM", "").strip().lower() == "dumb":
+        return True
+
+    return False
+
+
 def render_backend_state(
     *,
     stream: Optional[object] = None,
@@ -104,13 +218,7 @@ def render_backend_state(
     provider = size_provider or (lambda: terminal_size(fallback=fallback, stream=target))
     columns, lines = provider()
 
-    is_tty = False
-    isatty = getattr(target, "isatty", None)
-    if callable(isatty):
-        try:
-            is_tty = bool(isatty())
-        except Exception:
-            is_tty = False
+    is_tty = _is_stream_tty(target)
 
     term_value = str(os.environ.get("TERM", "")).strip().lower()
     force_cursor = bool(os.environ.get("LOGBAR_FORCE_TERMINAL_CURSOR", "").strip())
@@ -138,6 +246,15 @@ def render_backend_state(
     if not disable_styling:
         supports_styling = notebook or force_ansi or is_tty
 
+    headless = _is_headless_environment(notebook=notebook)
+
+    # A headless backend should never claim cursor/ANSI support; the flag is
+    # the canonical signal used by the rest of the renderer to suppress draws.
+    if headless:
+        supports_cursor = False
+        supports_ansi = False
+        supports_styling = False
+
     return RenderBackendState(
         columns=max(0, int(columns)),
         lines=max(0, int(lines)),
@@ -146,4 +263,5 @@ def render_backend_state(
         supports_cursor=supports_cursor,
         supports_ansi=supports_ansi,
         supports_styling=supports_styling,
+        headless=headless,
     )

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Tests for headless / AI-agent / notebook auto-detection."""
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from logbar.terminal import (
+    _is_headless_environment,
+    render_backend_state,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestHeadlessDetection(unittest.TestCase):
+    """Unit coverage for the environment-based headless detector."""
+
+    def setUp(self):
+        """Expose the detector to the test process by faking non-pytest mode."""
+
+        self._headless_patch = patch("logbar.terminal._running_under_pytest", return_value=False)
+        self._headless_patch.start()
+
+    def tearDown(self):
+        """Restore the pytest-detection patch."""
+
+        self._headless_patch.stop()
+
+    def test_force_progress_disables_headless_detection(self):
+        """``LOGBAR_FORCE_PROGRESS=1`` keeps the UI enabled."""
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"CI": "1", "LOGBAR_FORCE_PROGRESS": "1"},
+            clear=True,
+        ):
+            self.assertFalse(_is_headless_environment())
+
+    def test_disable_headless_detection_flag(self):
+        """``LOGBAR_DISABLE_HEADLESS_DETECTION=1`` keeps the UI enabled."""
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"CI": "1", "LOGBAR_DISABLE_HEADLESS_DETECTION": "1"},
+            clear=True,
+        ):
+            self.assertFalse(_is_headless_environment())
+
+    def test_ci_env_is_headless(self):
+        """CI variables are treated as non-interactive headless backends."""
+
+        with patch.dict("logbar.terminal.os.environ", {"CI": "true"}, clear=True):
+            self.assertTrue(_is_headless_environment())
+
+    def test_devin_env_is_headless(self):
+        """Devin session variables disable progress redrawing."""
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"DEVIN_OUTPOST_SESSION_ID": "devin-123"},
+            clear=True,
+        ):
+            self.assertTrue(_is_headless_environment())
+
+    def test_codex_env_is_headless(self):
+        """Codex session variables disable progress redrawing."""
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"CODEX_HOME": "/tmp/codex"},
+            clear=True,
+        ):
+            self.assertTrue(_is_headless_environment())
+
+    def test_jupyter_kernel_env_is_headless(self):
+        """Jupyter kernel parent markers disable progress redrawing."""
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"JPY_PARENT_PID": "12345"},
+            clear=True,
+        ):
+            self.assertTrue(_is_headless_environment())
+
+    def test_dumb_term_is_headless(self):
+        """A ``TERM=dumb`` terminal disables progress redrawing."""
+
+        with patch.dict("logbar.terminal.os.environ", {"TERM": "dumb"}, clear=True):
+            self.assertTrue(_is_headless_environment())
+
+    def test_notebook_backend_is_headless(self):
+        """The backend state reports ``headless=True`` for notebook targets."""
+
+        state = render_backend_state(notebook=True)
+        self.assertTrue(state.headless)
+        self.assertFalse(state.supports_cursor)
+        self.assertFalse(state.supports_ansi)
+        self.assertFalse(state.supports_styling)
+
+    def test_plain_terminal_is_not_headless(self):
+        """A clean, non-CI, non-agent environment is not headless."""
+
+        with patch.dict("logbar.terminal.os.environ", {}, clear=True):
+            self.assertFalse(_is_headless_environment())
+
+
+class TestHeadlessProgressBehavior(unittest.TestCase):
+    """End-to-end checks that headless mode suppresses progress output."""
+
+    _PROGRESS_SCRIPT = """
+import sys
+from io import StringIO
+sys.stdout = StringIO()
+# Import after replacing stdout so any import-time log lands in the buffer.
+from logbar.progress import ProgressBar
+
+for _ in ProgressBar(range(5)):
+    pass
+out = sys.stdout.getvalue()
+print("HAS_LOG", "LogBar: headless" in out, file=sys.stderr)
+print("HAS_PROGRESS", "[1 of 5]" in out or "100.0%" in out, file=sys.stderr)
+"""
+
+    @staticmethod
+    def _run_progress_in_subprocess(env: dict) -> subprocess.CompletedProcess:
+        """Run the progress script with the supplied environment."""
+
+        return subprocess.run(
+            [sys.executable, "-c", TestHeadlessProgressBehavior._PROGRESS_SCRIPT],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def test_devin_terminal_suppresses_progress_and_logs_state(self):
+        """A Devin-marked subprocess logs the headless state and skips redraws."""
+
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONPATH": str(REPO_ROOT),
+            "DEVIN_OUTPOST_SESSION_ID": "devin-test-123",
+        }
+        result = self._run_progress_in_subprocess(env)
+        self.assertIn("HAS_LOG True", result.stderr)
+        self.assertIn("HAS_PROGRESS False", result.stderr)
+
+    def test_codex_terminal_suppresses_progress_and_logs_state(self):
+        """A Codex-marked subprocess logs the headless state and skips redraws."""
+
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONPATH": str(REPO_ROOT),
+            "CODEX_HOME": "/tmp/codex-test",
+        }
+        result = self._run_progress_in_subprocess(env)
+        self.assertIn("HAS_LOG True", result.stderr)
+        self.assertIn("HAS_PROGRESS False", result.stderr)
+
+    def test_plain_terminal_renders_progress_and_no_headless_log(self):
+        """A clean subprocess renders progress and does not emit the headless log."""
+
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+        result = self._run_progress_in_subprocess(env)
+        self.assertIn("HAS_LOG False", result.stderr)
+        self.assertIn("HAS_PROGRESS True", result.stderr)
+
+    def test_logbar_shared_emits_single_headless_log(self):
+        """``LogBar.shared()`` emits the headless state once in a headless shell."""
+
+        script = """
+import sys
+from io import StringIO
+sys.stdout = StringIO()
+from logbar import LogBar
+
+log = LogBar.shared()
+log = LogBar.shared()  # second call should be idempotent
+out = sys.stdout.getvalue()
+# The single log line should appear exactly once.
+print("COUNT", out.count("high-frequency progress bars"), file=sys.stderr)
+"""
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONPATH": str(REPO_ROOT),
+            "DEVIN_OUTPOST_SESSION_ID": "devin-test-123",
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertIn("COUNT 1", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Use the PR template format.## Summary

LogBar now detects non-interactive, AI-agent, notebook, and CI environments and suppresses high-frequency progress-bar redraws, title animations, and the background refresh thread. A single `INFO` log records the operational state the first time LogBar is initialized in such an environment.

## What changed

- `logbar/terminal.py`
  - `RenderBackendState` gains a `headless` field.
  - `_is_headless_environment()` returns `True` when any of the following is detected:
    - Known CI variables (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `BUILDKITE`, ...).
    - Jupyter kernel markers (`JPY_PARENT_PID`, `IPYKERNEL_PARENT_PID`, ...).
    - AI-agent identifiers (`DEVIN_*`, `CODEX_*`, `SMITHERY_*`, `AIDER_*`, `CLAUDE_*`, `ANTHROPIC_*`, `COPILOT_*`, `__COG_*`).
    - `TERM=dumb`.
    - Explicit `notebook=True`.
  - Override switches: `LOGBAR_FORCE_PROGRESS=1` and `LOGBAR_DISABLE_HEADLESS_DETECTION=1` keep the UI enabled.
  - The test suite still renders because `_running_under_pytest()` disables headless detection under `pytest`.

- `logbar/progress.py`
  - `ProgressBar` computes `self._headless` from `render_backend_state(...)`.
  - `attach()`, `draw()`, and `_should_animate_title()` return early when `_headless`.

- `logbar/logbar.py`
  - `_ensure_background_refresh_thread()`, `_should_refresh_in_background()`, `_render_progress_stack_locked()`, and `_clear_progress_stack_locked()` skip redraw work in headless mode.
  - `_log_headless_state_once()` emits one `INFO` log when `LogBar.shared()` or `ProgressBar` first detects headless; guarded by an `RLock` for GIL=0 safety.

- `tests/test_headless.py`
  - Unit tests for detection of Devin, Codex, CI, Jupyter, `TERM=dumb`, and notebook backend.
  - Tests for `LOGBAR_FORCE_PROGRESS` / `LOGBAR_DISABLE_HEADLESS_DETECTION`.
  - End-to-end subprocess tests verifying that `ProgressBar` renders in a clean terminal and is suppressed under `DEVIN_OUTPOST_SESSION_ID` / `CODEX_HOME`, while logging the operational state exactly once.

## Verification

```bash
python -m pytest tests/ -q --tb=short --capture=sys
```

Result: `140 passed, 5 subtests passed`.

## Notes

The detection heuristic does *not* treat a non-TTY stdout as headless, because many real users redirect output to a file. Only environment markers / `TERM=dumb` / notebook mode trigger suppression.
