### PR TITLE
fix(terminal): detect pytest-xdist workers when os.environ is patched

### DIFF
--- a/logbar/terminal.py
+++ b/logbar/terminal.py
@@ -165,8 +165,16 @@ def _env_flag_enabled(name: str) -> bool:
     return value not in {"", "0", "false", "off", "no"}
 
 
+# xdist worker markers are set before test modules are imported; cache the flag
+# at import time so tests that patch ``os.environ`` still detect pytest correctly.
+_PYTEST_XDIST_WORKER = bool(os.environ.get("PYTEST_XDIST_WORKER"))
+
+
 def _running_under_pytest() -> bool:
     """Best-effort detection for pytest-driven terminal sessions."""
+
+    if _PYTEST_XDIST_WORKER:
+        return True
 
     argv0 = str(sys.argv[0]).lower() if sys.argv else ""
     return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in argv0


### PR DESCRIPTION
## Summary

`_running_under_pytest()` was failing to recognize pytest-xdist workers because those workers run with `sys.argv == ['-c']` and `PYTEST_CURRENT_TEST` is removed by tests that use `mock.patch.dict(os.environ, ..., clear=True)`. When `_running_under_pytest()` returned `False`, `_is_headless_environment()` treated the test session as a headless CI environment and zeroed out `supports_cursor/ansi/styling`, causing `test_render_backend_state_honors_cursor_policy` to fail under `pytest -n 8`.

Cache the `PYTEST_XDIST_WORKER` marker at module import time so it survives `os.environ` patches, and keep the existing `PYTEST_CURRENT_TEST` / `sys.argv[0]` checks for non-xdist runs.

```python
# before
def _running_under_pytest() -> bool:
    argv0 = str(sys.argv[0]).lower() if sys.argv else ""
    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in argv0

# after
_PYTEST_XDIST_WORKER = bool(os.environ.get("PYTEST_XDIST_WORKER"))

def _running_under_pytest() -> bool:
    if _PYTEST_XDIST_WORKER:
        return True
    argv0 = str(sys.argv[0]).lower() if sys.argv else ""
    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in argv0
```

Verified with `pytest tests/test_terminal.py tests/test_headless.py -n 8 -v` (16 passed) and the full suite `pytest tests/ -n 8` (140 passed).