### PR TITLE
fix(progress): make rolling/stacked/region spinners honor LOGBAR_ANIMATION and LOGBAR_PROGRESS_OUTPUT_INTERVAL

### DIFF
--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1362,12 +1362,24 @@ class LogBar(logging.Logger):
 
         return ProgressBar(iterable, owner=self, output_interval=output_interval).attach(self)
 
-    def spinner(self, title: str = "", *, interval: float = 0.5, tail_length: int = 4):
+    def spinner(
+        self,
+        title: str = "",
+        *,
+        interval: float = 0.5,
+        tail_length: int = 4,
+        output_interval: Optional[int] = None,
+    ):
         """Create and attach an indeterminate rolling spinner."""
 
         from logbar.progress import RollingProgressBar
 
-        bar = RollingProgressBar(owner=self, interval=interval, tail_length=tail_length)
+        bar = RollingProgressBar(
+            owner=self,
+            interval=interval,
+            tail_length=tail_length,
+            output_interval=output_interval,
+        )
         if title:
             bar.title(title)
         return bar.attach(self)

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -1364,13 +1364,28 @@ class ProgressBar:
 class RollingProgressBar(ProgressBar):
     """Indeterminate progress indicator with a rolling highlight."""
 
-    def __init__(self, owner: Optional["LogBarType"] = None, interval: float = 0.5, tail_length: int = 4):
+    def __init__(
+        self,
+        owner: Optional["LogBarType"] = None,
+        interval: float = 0.5,
+        tail_length: int = 4,
+        output_interval: Optional[int] = None,
+    ):
         """Create an indeterminate spinner-style progress bar."""
 
-        # Spinner animation already has its own wall-clock interval. Keep
-        # output throttling at 1 so the phase animation stays smooth unless a
-        # caller explicitly changes it later.
-        super().__init__(iterable=1, owner=owner, output_interval=1)
+        # Respect the global output-throttle default like determinate bars.
+        # The wall-clock interval still governs how often the spinner advances;
+        # output_interval only controls how many phase steps are skipped between
+        # rendered frames.
+        super().__init__(
+            iterable=1,
+            owner=owner,
+            output_interval=(
+                output_interval
+                if output_interval is not None
+                else _env_progress_output_interval()
+            ),
+        )
         self._interval = max(0.05, float(interval))
         self._tail_length = max(1, int(tail_length))
         self._phase = 0
@@ -1406,6 +1421,8 @@ class RollingProgressBar(ProgressBar):
     def pulse(self) -> "RollingProgressBar":
         """Advance the animation a single frame and redraw immediately."""
 
+        if not _env_animation_enabled():
+            return self
         self._advance_phase()
         self._next_spinner_refresh_at = time.monotonic() + self._interval
         self.draw()
@@ -1429,6 +1446,9 @@ class RollingProgressBar(ProgressBar):
 
         if not self._attached or self.closed:
             self._next_spinner_refresh_at = 0.0
+            return changed
+
+        if not _env_animation_enabled():
             return changed
 
         if self._next_spinner_refresh_at <= 0:

--- a/logbar/region_progress.py
+++ b/logbar/region_progress.py
@@ -112,10 +112,16 @@ class RegionRollingProgressBar(_SessionBoundProgressMixin, RollingProgressBar):
         region_id: str,
         interval: float = 0.5,
         tail_length: int = 4,
+        output_interval: Optional[int] = None,
     ) -> None:
         """Bind one rolling spinner to a split-pane session region."""
 
-        super().__init__(owner=None, interval=interval, tail_length=tail_length)
+        super().__init__(
+            owner=None,
+            interval=interval,
+            tail_length=tail_length,
+            output_interval=output_interval,
+        )
         self._bind_session(session, region_id)
 
     def _on_session_attach(self) -> None:

--- a/logbar/session.py
+++ b/logbar/session.py
@@ -221,6 +221,7 @@ class RegionScreenSession:
         title: str = "",
         interval: float = 0.5,
         tail_length: int = 4,
+        output_interval: Optional[int] = None,
     ):
         """Create and attach a pane-local rolling spinner."""
 
@@ -233,6 +234,7 @@ class RegionScreenSession:
                 region_id=target_region_id,
                 interval=interval,
                 tail_length=tail_length,
+                output_interval=output_interval,
             ).attach()
             if title:
                 bar.title(title)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -282,6 +282,70 @@ class TestProgress(unittest.TestCase):
 
         cache_clear()
 
+    def test_spinner_output_interval_respects_env(self):
+        """Rolling progress bars inherit LOGBAR_PROGRESS_OUTPUT_INTERVAL."""
+
+        cache_clear = progress_module._env_progress_output_interval.cache_clear
+
+        with patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10"}):
+            cache_clear()
+            pb = log.spinner(title="throttled")
+            try:
+                self.assertEqual(pb._output_interval, 10)
+            finally:
+                with redirect_stdout(StringIO()):
+                    pb.close()
+
+        cache_clear()
+
+    def test_spinner_output_interval_explicit_overrides_env(self):
+        """An explicit output_interval keyword overrides the env default."""
+
+        cache_clear = progress_module._env_progress_output_interval.cache_clear
+
+        with patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10"}):
+            cache_clear()
+            pb = log.spinner(title="explicit", output_interval=5)
+            try:
+                self.assertEqual(pb._output_interval, 5)
+            finally:
+                with redirect_stdout(StringIO()):
+                    pb.close()
+
+        cache_clear()
+
+    def test_spinner_animation_disabled_by_logbar_animation_env(self):
+        """LOGBAR_ANIMATION=0 freezes automatic spinner phase updates."""
+
+        script = (
+            "from logbar import LogBar\n"
+            "log = LogBar.shared(override_logger=True)\n"
+            "spinner = log.spinner(title='frozen', interval=10.0)\n"
+            "spinner._tick_background_refresh(spinner._next_spinner_refresh_at + 1.0)\n"
+            "print('phase', spinner._phase)\n"
+            "spinner.close()\n"
+        )
+
+        enabled = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            env={},
+            check=True,
+        )
+        self.assertIn("phase 1", enabled.stdout)
+
+        disabled = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            env={"LOGBAR_ANIMATION": "0"},
+            check=True,
+        )
+        self.assertIn("phase 0", disabled.stdout)
+
     def test_progress_output_interval_skips_intermediate_draws_but_flushes_final_step(self):
         """Skip intermediate frames while still forcing the final 100% snapshot."""
 

--- a/tests/test_region_progress.py
+++ b/tests/test_region_progress.py
@@ -5,11 +5,13 @@
 
 """Tests for pane-local progress bars rendered through split sessions."""
 
+import os
 import time
 import unittest
 from unittest import mock
 
 from logbar.layout import LeafNode, SplitDirection, SplitNode
+from logbar.progress import _env_animation_enabled, _env_progress_output_interval
 from logbar.session import RegionScreenSession
 from tests._stream_helpers import FakeTTY, MirroredTTY, real_terminal_stream
 
@@ -309,3 +311,59 @@ class TestRegionProgress(unittest.TestCase):
 
             left_spinner.close()
             session.close()
+
+    def test_region_spinner_output_interval_respects_env(self):
+        """Region rolling bars inherit LOGBAR_PROGRESS_OUTPUT_INTERVAL."""
+
+        cache_clear = _env_progress_output_interval.cache_clear
+        try:
+            with mock.patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10"}), \
+                 mock.patch("logbar.progress.terminal_size", return_value=(80, 24)):
+                cache_clear()
+                session = RegionScreenSession(
+                    layout_root=SplitNode(
+                        direction=SplitDirection.LEFT_RIGHT,
+                        children=(LeafNode("left"),),
+                    ),
+                    stream=FakeTTY(),
+                    size_provider=lambda: (80, 4),
+                    use_alternate_screen=False,
+                    auto_render=False,
+                )
+                spinner = session.spinner(region_id="left", title="region-throttled")
+                try:
+                    self.assertEqual(spinner._output_interval, 10)
+                finally:
+                    spinner.close()
+                    session.close()
+        finally:
+            cache_clear()
+
+    def test_region_spinner_animation_disabled_by_logbar_animation_env(self):
+        """LOGBAR_ANIMATION=0 freezes region spinner phase updates."""
+
+        anim_cache_clear = _env_animation_enabled.cache_clear
+        try:
+            with mock.patch.dict(os.environ, {"LOGBAR_ANIMATION": "0"}), \
+                 mock.patch("logbar.progress.terminal_size", return_value=(80, 24)):
+                anim_cache_clear()
+                session = RegionScreenSession(
+                    layout_root=SplitNode(
+                        direction=SplitDirection.LEFT_RIGHT,
+                        children=(LeafNode("left"),),
+                    ),
+                    stream=FakeTTY(),
+                    size_provider=lambda: (80, 4),
+                    use_alternate_screen=False,
+                    auto_render=False,
+                )
+                spinner = session.spinner(region_id="left", title="frozen", interval=10.0)
+                try:
+                    initial_phase = spinner._phase
+                    spinner._tick_background_refresh(spinner._next_spinner_refresh_at + 1.0)
+                    self.assertEqual(spinner._phase, initial_phase)
+                finally:
+                    spinner.close()
+                    session.close()
+        finally:
+            anim_cache_clear()


### PR DESCRIPTION
## Summary

`RollingProgressBar` (used by `LogBar.spinner()`, `RegionScreenSession.spinner()`, and nested/region spinner bars) was ignoring the two global environment knobs:

- `LOGBAR_PROGRESS_OUTPUT_INTERVAL` — the constructor hard-coded `output_interval=1`, so every phase change rendered immediately regardless of the env default.
- `LOGBAR_ANIMATION=0` — the rolling phase animation kept advancing via the background refresh loop and `pulse()`, even though title highlight was already disabled.

## What changed

- `RollingProgressBar.__init__` now accepts `output_interval` and defaults to `_env_progress_output_interval()` when not explicitly supplied, matching `ProgressBar`.
- `RegionRollingProgressBar.__init__`, `LogBar.spinner()`, and `RegionScreenSession.spinner()` gained an `output_interval` keyword and forward it.
- `RollingProgressBar._tick_background_refresh()` and `pulse()` now short-circuit when `_env_animation_enabled()` is `False`, so `LOGBAR_ANIMATION=0` freezes the rolling indicator.

```py
os.environ.setdefault("LOGBAR_ANIMATION", "0")
os.environ.setdefault("LOGBAR_PROGRESS_OUTPUT_INTERVAL", "10")

log.spinner("Loading")          # respects both env vars
session.spinner(title="job")    # respects both env vars
```

## Tests

- Added `test_spinner_output_interval_respects_env`
- Added `test_spinner_output_interval_explicit_overrides_env`
- Added `test_spinner_animation_disabled_by_logbar_animation_env`
- Added `test_region_spinner_output_interval_respects_env`
- Added `test_region_spinner_animation_disabled_by_logbar_animation_env`

All tests in `tests/test_progress.py` and `tests/test_region_progress.py` pass.

Link to Devin session: https://app.devin.ai/sessions/2a91628c0f1343acb9012c5f87bd6977
Requested by: @Qubitium