### PR TITLE
fix(progress): honor LOGBAR_PROGRESS_OUTPUT_INTERVAL and LOGBAR_ANIMATION for stacked/region/rolling bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 - Sub-cell Unicode bar rasterization for smoother, more accurate terminal fills.
 - Built-in styling for progress bar fills, colors, gradients, and head glyphs.
 - Animated progress titles with a subtle sweeping highlight.
-  Set `LOGBAR_ANIMATION=0` to disable the highlight animation.
+  Set `LOGBAR_ANIMATION=0` to disable the highlight animation (applies to stacked, region, and spinner bars).
 - Progress output throttling for reducing redraw churn in batch-heavy jobs.
-  Set `LOGBAR_PROGRESS_OUTPUT_INTERVAL=10` to render every 10 logical updates instead of every update.
+  Set `LOGBAR_PROGRESS_OUTPUT_INTERVAL=10` to render every 10 logical updates instead of every update (applies to all progress bar types including spinners and split-pane region bars).
 - Column-aware table printer with spans, width hints, and `fit` sizing.
 - Zero dependencies; works anywhere Python runs.
 
@@ -179,7 +179,7 @@ for _ in log.pb(500, output_interval=10).title("Quantizing"):
     time.sleep(0.01)
 ```
 
-`output_interval=10` means LogBar will emit a fresh snapshot after roughly every 10 logical progress steps, while still forcing the last pending step to render before the bar closes. Set `LOGBAR_PROGRESS_OUTPUT_INTERVAL=10` to apply the same default process-wide.
+`output_interval=10` means LogBar will emit a fresh snapshot after roughly every 10 logical progress steps, while still forcing the last pending step to render before the bar closes. Set `LOGBAR_PROGRESS_OUTPUT_INTERVAL=10` to apply the same default process-wide. This default is now honored by stacked progress bars, pane-local region bars, and rolling spinners.
 
 Manual mode gives full control when you need to interleave logging and redraws:
 
@@ -211,7 +211,7 @@ with log.spinner("Loading model") as spinner:
     warm_up()
 ```
 
-The rolling bar animates automatically while attached. Close it explicitly with `spinner.close()` if you are not using the context manager. Set `LOGBAR_ANIMATION=0` to disable the title highlight sweep on progress labels.
+The rolling bar animates automatically while attached. Close it explicitly with `spinner.close()` if you are not using the context manager. Set `LOGBAR_ANIMATION=0` to disable the title highlight sweep on progress labels. You can also set `LOGBAR_PROGRESS_OUTPUT_INTERVAL=10` to throttle the spinner's phase updates, which is helpful when many spinners are running in headless or CI environments.
 
 ### Multiple Progress Bars
 
@@ -380,7 +380,7 @@ with log.pb(items).manual() as pb:
 - Deduplicated level methods: `debug.once`, `info.once`, `warn.once`, `error.once`, `critical.once`.
 - `setLevel(level)` accepts strings like `"INFO"`, `"WARN"`, `"CRIT"`, numeric levels, numeric strings, and constants such as `LogBar.WARNING`.
 - `pb(iterable_or_total, output_interval=None)` creates and attaches a progress bar.
-- `spinner(title="", interval=0.5, tail_length=4)` creates and attaches an indeterminate rolling progress bar.
+- `spinner(title="", output_interval=None, interval=0.5, tail_length=4)` creates and attaches an indeterminate rolling progress bar.
 - `columns(..., cols=None, width=None, padding=2)` creates a column printer.
 
 ## `ProgressBar`

--- a/README.md
+++ b/README.md
@@ -369,6 +369,16 @@ with log.pb(items).manual() as pb:
 - Combine columns and progress bars by logging summaries at key checkpoints.
 - Use `log.warn.once(...)` to keep noisy health checks readable.
 - For multi-line messages, pre-format text and pass it as a single string; LogBar keeps borders intact.
+- In headless, notebook, or CI environments, LogBar auto-disables high-frequency progress output. Set `LOGBAR_FORCE_PROGRESS=1` to render anyway, or `LOGBAR_DISABLE_HEADLESS_DETECTION=1` to disable the heuristic.
+
+# Environment Variables
+
+- `LOGBAR_ANIMATION` — Set to `0`/`false`/`off` to disable the title highlight sweep.
+- `LOGBAR_PROGRESS_OUTPUT_INTERVAL` — Default logical step interval between progress renders (default `1`). Applies to stacked bars, region panes, and rolling spinners.
+- `LOGBAR_FORCE_PROGRESS=1` — Force progress rendering in headless/AI-agent/notebook/CI shells.
+- `LOGBAR_DISABLE_HEADLESS_DETECTION=1` — Disable headless/notebook/CI auto-detection.
+- `NO_COLOR=1` or `ANSI_COLORS_DISABLED=1` — Disable ANSI colors.
+- `COLUMNS` / `LINES` — Override the detected terminal size.
 
 # API Reference
 

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1362,12 +1362,24 @@ class LogBar(logging.Logger):
 
         return ProgressBar(iterable, owner=self, output_interval=output_interval).attach(self)
 
-    def spinner(self, title: str = "", *, interval: float = 0.5, tail_length: int = 4):
+    def spinner(
+        self,
+        title: str = "",
+        *,
+        output_interval: Optional[int] = None,
+        interval: float = 0.5,
+        tail_length: int = 4,
+    ):
         """Create and attach an indeterminate rolling spinner."""
 
         from logbar.progress import RollingProgressBar
 
-        bar = RollingProgressBar(owner=self, interval=interval, tail_length=tail_length)
+        bar = RollingProgressBar(
+            owner=self,
+            output_interval=output_interval,
+            interval=interval,
+            tail_length=tail_length,
+        )
         if title:
             bar.title(title)
         return bar.attach(self)

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -1364,16 +1364,30 @@ class ProgressBar:
 class RollingProgressBar(ProgressBar):
     """Indeterminate progress indicator with a rolling highlight."""
 
-    def __init__(self, owner: Optional["LogBarType"] = None, interval: float = 0.5, tail_length: int = 4):
+    def __init__(
+        self,
+        owner: Optional["LogBarType"] = None,
+        *,
+        output_interval: Optional[int] = None,
+        interval: float = 0.5,
+        tail_length: int = 4,
+    ):
         """Create an indeterminate spinner-style progress bar."""
 
-        # Spinner animation already has its own wall-clock interval. Keep
-        # output throttling at 1 so the phase animation stays smooth unless a
-        # caller explicitly changes it later.
-        super().__init__(iterable=1, owner=owner, output_interval=1)
+        # Honor the global output interval default so callers can throttle
+        # spinner redraws with LOGBAR_PROGRESS_OUTPUT_INTERVAL, while still
+        # defaulting to one frame per tick for smooth local animation.
+        super().__init__(
+            iterable=1,
+            owner=owner,
+            output_interval=(
+                _env_progress_output_interval() if output_interval is None else output_interval
+            ),
+        )
         self._interval = max(0.05, float(interval))
         self._tail_length = max(1, int(tail_length))
         self._phase = 0
+        self._pending_spinner_steps = 0
         self.ui_show_left_steps = False
         self._next_spinner_refresh_at = 0.0
 
@@ -1439,9 +1453,19 @@ class RollingProgressBar(ProgressBar):
             return changed
 
         steps = max(1, int((now - self._next_spinner_refresh_at) // self._interval) + 1)
-        self._advance_phase(steps=steps)
-        self._next_spinner_refresh_at += self._interval * steps
-        return True
+        # Reset the wall-clock deadline immediately so missed ticks don't pile up.
+        self._next_spinner_refresh_at = now + self._interval
+
+        # Throttle the spinner's phase advances with the same output interval used
+        # for determinate bars (default from LOGBAR_PROGRESS_OUTPUT_INTERVAL).
+        self._pending_spinner_steps += steps
+        if self._pending_spinner_steps >= self._output_interval:
+            advance = self._pending_spinner_steps
+            self._pending_spinner_steps = 0
+            self._advance_phase(steps=advance)
+            return True
+
+        return changed
 
     @_render_locked
     def _advance_phase(self, steps: int = 1) -> None:

--- a/logbar/region_progress.py
+++ b/logbar/region_progress.py
@@ -51,6 +51,9 @@ class _SessionBoundProgressMixin:
 
         del logger
 
+        if getattr(self, "_headless", False):
+            return self
+
         with _RENDER_LOCK:
             if self.closed or self._attached:
                 return self
@@ -81,6 +84,9 @@ class _SessionBoundProgressMixin:
     def draw(self, force: bool = False):
         """Resolve and optionally paint the pane-local progress footer."""
 
+        if getattr(self, "_headless", False):
+            return
+
         with _RENDER_LOCK:
             self._session._draw_progress_bar(self._region_id, self, force=force)
 
@@ -110,12 +116,18 @@ class RegionRollingProgressBar(_SessionBoundProgressMixin, RollingProgressBar):
         *,
         session: "RegionScreenSession",
         region_id: str,
+        output_interval: Optional[int] = None,
         interval: float = 0.5,
         tail_length: int = 4,
     ) -> None:
         """Bind one rolling spinner to a split-pane session region."""
 
-        super().__init__(owner=None, interval=interval, tail_length=tail_length)
+        super().__init__(
+            owner=None,
+            output_interval=output_interval,
+            interval=interval,
+            tail_length=tail_length,
+        )
         self._bind_session(session, region_id)
 
     def _on_session_attach(self) -> None:

--- a/logbar/session.py
+++ b/logbar/session.py
@@ -120,6 +120,7 @@ class RegionScreenSession:
             use_alternate_screen=use_alternate_screen,
         )
         self._auto_render = bool(auto_render)
+        self._closed = False
         self._background_refresh_enabled = (
             self._auto_render if background_refresh is None else (bool(background_refresh) and self._auto_render)
         )
@@ -219,6 +220,7 @@ class RegionScreenSession:
         *,
         region_id: Optional[str] = None,
         title: str = "",
+        output_interval: Optional[int] = None,
         interval: float = 0.5,
         tail_length: int = 4,
     ):
@@ -231,6 +233,7 @@ class RegionScreenSession:
             bar = RegionRollingProgressBar(
                 session=self,
                 region_id=target_region_id,
+                output_interval=output_interval,
                 interval=interval,
                 tail_length=tail_length,
             ).attach()
@@ -244,16 +247,32 @@ class RegionScreenSession:
         with _RENDER_LOCK:
             state, size_changed, _ = self._resolve_render_snapshot()
             now = time.monotonic()
-            changed = size_changed or force
+            force_refresh = size_changed or force
+            precomputed: dict[object, str] = {}
 
             for pane in self._pane_states.values():
                 for pb in list(pane.progress_bars):
                     tick = getattr(pb, "_tick_background_refresh", None)
-                    if callable(tick) and tick(now):
-                        changed = True
+                    if not callable(tick) or not tick(now):
+                        continue
 
-            if changed:
-                return self.render(backend_state=state, force_progress_refresh=True)
+                    width = self._progress_width(pb.region_id, state)
+                    rendered = pb._resolve_rendered_line(
+                        width,
+                        force=False,
+                        allow_repeat=True,
+                        backend_state=state,
+                        style_enabled=state.supports_styling,
+                    )
+                    if rendered is not None:
+                        precomputed[pb] = rendered
+
+            if force_refresh or precomputed:
+                return self.render(
+                    backend_state=state,
+                    force_progress_refresh=force_refresh,
+                    precomputed=precomputed or None,
+                )
 
             return self._screen.compose_lines(backend_state=state)
 
@@ -262,15 +281,19 @@ class RegionScreenSession:
         *,
         backend_state=None,
         force_progress_refresh: bool = False,
+        precomputed: Optional[dict[object, str]] = None,
     ) -> list[str]:
         """Render the current layout frame through the bound screen backend."""
 
         with _RENDER_LOCK:
+            if self._closed:
+                return []
             state, size_changed, viewports = self._resolve_render_snapshot(backend_state)
             self._sync_all_pane_footers(
                 backend_state=state,
                 force=force_progress_refresh or size_changed,
                 allow_repeat=True,
+                precomputed=precomputed,
                 viewports=viewports,
             )
             lines = self._screen.render(backend_state=state)
@@ -282,6 +305,7 @@ class RegionScreenSession:
 
         self.stop_background_refresh()
         with _RENDER_LOCK:
+            self._closed = True
             self._screen.close()
             self._last_render_size = None
 
@@ -458,7 +482,7 @@ class RegionScreenSession:
                 continue
 
             active_bars.append(pb)
-            bar_force = force or pb in self._dirty_progress_bars
+            bar_force = force
             rendered = precomputed.get(pb) if precomputed is not None else None
             if rendered is None:
                 rendered = pb._resolve_rendered_line(
@@ -483,6 +507,7 @@ class RegionScreenSession:
         backend_state,
         force: bool = False,
         allow_repeat: bool = True,
+        precomputed: Optional[dict[object, str]] = None,
         viewports: Optional[dict[str, object]] = None,
     ) -> None:
         """Recompose every pane footer that currently has progress rows."""
@@ -497,6 +522,7 @@ class RegionScreenSession:
                     backend_state=backend_state,
                     force=force,
                     allow_repeat=allow_repeat,
+                    precomputed=precomputed,
                     viewports=resolved_viewports,
                 )
 
@@ -561,12 +587,12 @@ class RegionScreenSession:
             self._sync_pane_footer(
                 region_id,
                 backend_state=state,
-                force=True,
+                force=False,
                 allow_repeat=True,
                 viewports=viewports,
             )
-            if self._auto_render:
-                self.render(backend_state=state, force_progress_refresh=True)
+            if self._auto_render and not self._closed:
+                self.render(backend_state=state, force_progress_refresh=False)
             has_active_progress_bars = self._has_active_progress_bars()
 
         if attached:
@@ -594,11 +620,12 @@ class RegionScreenSession:
                 self._sync_pane_footer(
                     region_id,
                     backend_state=state,
-                    force=True,
+                    force=False,
                     allow_repeat=True,
                     viewports=viewports,
                 )
-                self.render(backend_state=state, force_progress_refresh=True)
+                if not self._closed:
+                    self.render(backend_state=state, force_progress_refresh=False)
 
     def _draw_progress_bar(self, region_id: str, pb: object, *, force: bool = False) -> None:
         """Resolve one pane-local progress bar and optionally repaint the screen."""
@@ -627,7 +654,7 @@ class RegionScreenSession:
                 viewports=viewports,
             )
             self._dirty_progress_bars.discard(pb)
-            if self._auto_render:
+            if self._auto_render and not self._closed:
                 self.render(backend_state=state, force_progress_refresh=size_changed)
 
     def _resolve_backend_state(self, backend_state=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LogBar"
-version = "0.4.4"
+version = "0.4.5"
 description = "A unified Logger and ProgressBar util with zero dependencies."
 readme = "README.md"
 requires-python = ">=3"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -741,3 +741,45 @@ class TestProgress(unittest.TestCase):
         self.assertGreaterEqual(after_phase - initial_phase, pulses)
         self.assertGreaterEqual(pulse_duration, 5.0)
         self.assertIn('Pulse', last_line)
+
+    def test_spinner_output_interval_respects_env(self):
+        """Rolling bars inherit LOGBAR_PROGRESS_OUTPUT_INTERVAL for throttling."""
+
+        cache_clear = progress_module._env_progress_output_interval.cache_clear
+
+        with patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10"}):
+            cache_clear()
+
+            class FakeTTY(StringIO):
+                def isatty(self):
+                    return True
+
+            with redirect_stdout(FakeTTY()):
+                pb = log.spinner(title="S", interval=10.0)
+                try:
+                    for _ in range(25):
+                        pb.pulse()
+                finally:
+                    pb.close()
+
+            self.assertEqual(pb._output_interval, 10)
+            self.assertGreater(pb._phase, 0)
+
+        cache_clear()
+
+    def test_rolling_progress_bar_output_interval_defaults_from_env(self):
+        """RollingProgressBar reads the global output interval env default."""
+
+        cache_clear = progress_module._env_progress_output_interval.cache_clear
+
+        with patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10"}):
+            cache_clear()
+            from logbar.progress import RollingProgressBar
+
+            pb = RollingProgressBar(interval=10.0)
+            try:
+                self.assertEqual(pb._output_interval, 10)
+            finally:
+                pb.close()
+
+        cache_clear()

--- a/tests/test_region_progress.py
+++ b/tests/test_region_progress.py
@@ -5,10 +5,13 @@
 
 """Tests for pane-local progress bars rendered through split sessions."""
 
+import os
+import re
 import time
 import unittest
 from unittest import mock
 
+from logbar import progress as progress_module
 from logbar.layout import LeafNode, SplitDirection, SplitNode
 from logbar.session import RegionScreenSession
 from tests._stream_helpers import FakeTTY, MirroredTTY, real_terminal_stream
@@ -309,3 +312,70 @@ class TestRegionProgress(unittest.TestCase):
 
             left_spinner.close()
             session.close()
+
+    def test_region_progress_output_interval_respects_env_with_dynamic_titles(self):
+        """Pane-local bars throttle dynamic title changes with LOGBAR_PROGRESS_OUTPUT_INTERVAL."""
+
+        cache_clear = progress_module._env_progress_output_interval.cache_clear
+
+        with mock.patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10", "NO_COLOR": "1"}), \
+             mock.patch("logbar.progress.terminal_size", return_value=(120, 8)), \
+             mock.patch("logbar.logbar.terminal_size", return_value=(120, 8)):
+            cache_clear()
+            stream = FakeTTY()
+            session = RegionScreenSession.columns(
+                "left", "right",
+                weights=(1, 1),
+                stream=stream,
+                size_provider=lambda: (120, 8),
+                use_alternate_screen=False,
+                auto_render=True,
+            )
+            left = session.pb(30, region_id="left").manual()
+            for i in range(1, 31):
+                left.current_iter_step = i
+                left.title(f"L {i}").draw()
+            session.render()
+            session.close()
+
+            cleaned = re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", stream.getvalue())
+            titles = re.findall(r"L \d+", cleaned)
+            # With output_interval=10 we expect one of L 10, L 20, L 30, not all 30.
+            self.assertLess(len(set(titles)), 30)
+            self.assertTrue(any("L 10" in title for title in titles))
+            self.assertTrue(any("L 30" in title for title in titles))
+
+        cache_clear()
+
+    def test_region_spinner_output_interval_respects_env(self):
+        """Pane-local rolling bars honor LOGBAR_PROGRESS_OUTPUT_INTERVAL for phase ticks."""
+
+        cache_clear = progress_module._env_progress_output_interval.cache_clear
+
+        with mock.patch.dict(os.environ, {"LOGBAR_PROGRESS_OUTPUT_INTERVAL": "10", "NO_COLOR": "1"}), \
+             mock.patch("logbar.progress.terminal_size", return_value=(80, 12)), \
+             mock.patch("logbar.logbar.terminal_size", return_value=(80, 12)):
+            cache_clear()
+            stream = FakeTTY()
+            session = RegionScreenSession.columns(
+                "left",
+                weights=(1,),
+                stream=stream,
+                size_provider=lambda: (80, 12),
+                use_alternate_screen=False,
+                auto_render=True,
+            )
+            spinner = session.spinner(region_id="left", title="S", interval=10.0)
+            for _ in range(25):
+                spinner.pulse()
+            session.render()
+            session.close()
+
+            self.assertEqual(spinner._output_interval, 10)
+            cleaned = re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", stream.getvalue())
+            # Each rendered frame starts with the title followed by the bar.
+            frames = cleaned.count("S ")
+            self.assertGreaterEqual(frames, 2)
+            self.assertLess(frames, 25)
+
+        cache_clear()


### PR DESCRIPTION
## Summary

Default stacked (`ProgressBar`), region (`RegionProgressBar`), and rolling/spinner (`RollingProgressBar`, `RegionRollingProgressBar`) bars now honor the environment defaults set by:

```python
os.environ.setdefault("LOGBAR_ANIMATION", "0")
os.environ.setdefault("LOGBAR_PROGRESS_OUTPUT_INTERVAL", "10")
```

`LOGBAR_PROGRESS_OUTPUT_INTERVAL` is now threaded through `RollingProgressBar` and `RegionRollingProgressBar` instead of being hard-coded to `1`. For the spinner, phase advances are accumulated and only applied once the pending steps reach `_output_interval`, so the same render-throttle interval is used for both determinate and indeterminate bars.

`RegionScreenSession` no longer treats every dirty bar as a forced refresh. The background refresh precomputes frames for time-based bars and lets each bar's `_resolve_rendered_line` decide whether it is actually due, so `output_interval` is respected for title animation ticks and spinner ticks in pane-local progress.

Headless/auto-disable detection is now also checked in `_SessionBoundProgressMixin.attach()` and `draw()`, preventing region bars from trying to paint when the environment has auto-disabled progress output.

## Changes

```python
# RollingProgressBar now accepts output_interval and defaults it from env.
RollingProgressBar(
    output_interval=_env_progress_output_interval() if output_interval is None else output_interval,
    ...
)

# _tick_background_refresh now buffers spinner phase steps against _output_interval.
self._pending_spinner_steps += steps
if self._pending_spinner_steps >= self._output_interval:
    advance = self._pending_spinner_steps
    self._pending_spinner_steps = 0
    self._advance_phase(steps=advance)
    return True

# Region factories now accept and forward output_interval.
LogBar.spinner(..., output_interval=...)
RegionScreenSession.spinner(..., output_interval=...)
RegionScreenSession.refresh_progress() precomputes rendered frames and renders with force=False.
RegionScreenSession.render() accepts an optional precomputed dict.
```

Tests were added for spinner/region `LOGBAR_PROGRESS_OUTPUT_INTERVAL` behavior.
