### PR TITLE
perf: reduce drawing latency and math overhead for progress, columns and log paths

### DIFF
--- a/logbar/drawing.py
+++ b/logbar/drawing.py
@@ -51,6 +51,8 @@ _ANSI_BASIC_FG = {
 def strip_ansi(text: str) -> str:
     """Remove ANSI control sequences while leaving printable text intact."""
 
+    if "\x1b" not in text:
+        return text
     return ANSI_ESCAPE_RE.sub("", text)
 
 
@@ -266,6 +268,9 @@ def visible_length(text: str) -> int:
     if not text:
         return 0
 
+    if text.isascii() and text.isprintable():
+        return len(text)
+
     printable = 0
     for is_ansi, _token, width in iter_display_atoms(text):
         if not is_ansi:
@@ -436,6 +441,11 @@ def truncate_ansi(text: str, limit: int) -> str:
 
     if limit <= 0:
         return ANSI_RESET
+
+    if text.isascii() and text.isprintable():
+        if len(text) <= limit:
+            return text
+        return text[:limit]
 
     result = []
     printable = 0

--- a/logbar/drawing.py
+++ b/logbar/drawing.py
@@ -528,15 +528,37 @@ class CellBarRenderer:
         full_cells, partial_units = divmod(filled_units, resolution)
         occupied_cells = min(width, full_cells + (1 if partial_units else 0))
 
+        if partial_units:
+            partial_char = self._partial_char(partial_units)
+            if full_cells == 0:
+                plain = partial_char + self.empty_char * (width - 1)
+            else:
+                plain = (
+                    self.fill_char * full_cells
+                    + partial_char
+                    + self.empty_char * (width - full_cells - 1)
+                )
+        elif full_cells == 0:
+            plain = self.empty_char * width
+        else:
+            empty_count = width - full_cells
+            if self.head_char:
+                plain = (
+                    self.fill_char * (full_cells - 1)
+                    + self.head_char
+                    + self.empty_char * empty_count
+                )
+            else:
+                plain = self.fill_char * full_cells + self.empty_char * empty_count
+
+        if not select_color and not empty_color and not head_color:
+            return BarRenderResult(plain=plain, rendered=plain)
+
         color_selector = select_color or (lambda idx, total: "")
-        plain_chars: list[str] = []
         rendered_segments: list[str] = []
         current_color: Optional[str] = None
 
-        for idx in range(width):
-            char = self._cell_char(idx, full_cells, partial_units)
-            plain_chars.append(char)
-
+        for idx, char in enumerate(plain):
             color = ""
             if idx < occupied_cells:
                 color = color_selector(idx, occupied_cells)
@@ -557,21 +579,7 @@ class CellBarRenderer:
         if current_color:
             rendered_segments.append(ANSI_RESET)
 
-        plain = "".join(plain_chars)
         return BarRenderResult(plain=plain, rendered="".join(rendered_segments))
-
-    def _cell_char(self, idx: int, full_cells: int, partial_units: int) -> str:
-        """Pick the visible glyph for a single cell of the bar."""
-
-        if idx < full_cells:
-            if self.head_char and partial_units == 0 and idx == full_cells - 1:
-                return self.head_char
-            return self.fill_char
-
-        if partial_units and idx == full_cells:
-            return self._partial_char(partial_units)
-
-        return self.empty_char
 
     def _partial_char(self, partial_units: int) -> str:
         """Convert a partial fill amount into the closest ramp character."""

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -279,12 +279,15 @@ def render_lock() -> threading.RLock:
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard for type checkers
     from .progress import ProgressBar
 
-def _sync_default_coordinator_state() -> None:
+def _sync_default_coordinator_state(name=None, value=None) -> None:
     """Mirror coordinator-owned state onto legacy module globals for compatibility."""
 
-    state = _DEFAULT_RENDER_COORDINATOR.state
-    for field_name in state.field_names():
-        globals()[field_name] = getattr(state, field_name)
+    if name is None:
+        state = _DEFAULT_RENDER_COORDINATOR.state
+        for field_name in state.field_names():
+            globals()[field_name] = getattr(state, field_name)
+    else:
+        globals()[name] = value
 
 
 def _coordinator_state():
@@ -294,7 +297,7 @@ def _coordinator_state():
 
 
 _DEFAULT_RENDER_COORDINATOR = RenderCoordinator(
-    on_state_change=lambda _name, _value: _sync_default_coordinator_state()
+    on_state_change=lambda name, value: _sync_default_coordinator_state(name, value)
 )
 _ROOT_STACK_REGION = LineRegion(vertical_anchor="bottom")
 _DEFAULT_RENDER_COORDINATOR.register_region(_DEFAULT_RENDER_COORDINATOR.root_region_id, _ROOT_STACK_REGION)
@@ -902,6 +905,10 @@ def _render_progress_stack_locked(
     rows = state.lines
 
     bars = _active_progress_bars()
+    if not bars and not precomputed and coordinator_state._last_drawn_progress_count == 0:
+        _record_progress_activity_locked()
+        return
+
     with _STATE_LOCK:
         dirty_bars = set(coordinator_state._dirty_progress_bars)
     to_remove = []

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -905,7 +905,12 @@ def _render_progress_stack_locked(
     rows = state.lines
 
     bars = _active_progress_bars()
-    if not bars and not precomputed and coordinator_state._last_drawn_progress_count == 0:
+    if (
+        state.supports_cursor
+        and not bars
+        and not precomputed
+        and coordinator_state._last_drawn_progress_count == 0
+    ):
         _record_progress_activity_locked()
         return
 

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -239,6 +239,7 @@ class ProgressStyle:
         )
         return result.plain, result.rendered
 
+    @lru_cache(maxsize=4)
     def _bar_renderer(self, units_per_cell: int = SUBCELL_RESOLUTION) -> CellBarRenderer:
         """Build the low-level bar renderer for this style."""
 

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -1019,15 +1019,17 @@ class ProgressBar:
                         raise
 
     @_render_locked
-    def calc_time(self, iteration):
+    def calc_time(self, iteration, total_steps=None):
         """Return elapsed and estimated remaining time for the progress line."""
 
+        if total_steps is None:
+            total_steps = len(self)
         used_time = int(time.time() - self.time)
         formatted_time = str(datetime.timedelta(seconds=used_time))
         completed = iteration
         if self._render_mode == RenderMode.AUTO and iteration > 0:
             completed = iteration - 1
-        remaining = str(datetime.timedelta(seconds=int((used_time / max(completed, 1)) * len(self))))
+        remaining = str(datetime.timedelta(seconds=int((used_time / max(completed, 1)) * total_steps)))
         return f"{formatted_time} / {remaining}"
 
     @_render_locked
@@ -1047,10 +1049,11 @@ class ProgressBar:
 
         total_steps = len(self)
         effective_total = total_steps if total_steps else 1
+        current_step = self.step()
 
-        percent_num = self.step() / float(effective_total)
+        percent_num = current_step / float(effective_total)
         percent = ("{0:.1f}").format(100 * percent_num)
-        log_text = f"{self.calc_time(self.step())} [{self.step()}/{total_steps}] {percent}%"
+        log_text = f"{self.calc_time(current_step, total_steps)} [{current_step}/{total_steps}] {percent}%"
 
         pre_bar_size = 0
 
@@ -1060,7 +1063,7 @@ class ProgressBar:
             pre_bar_size += self.max_subtitle_len + 1
 
         if self.ui_show_left_steps:
-            left_current = self.step() - self.ui_show_left_steps_offset
+            left_current = current_step - self.ui_show_left_steps_offset
             left_total = total_steps - self.ui_show_left_steps_offset
             self.ui_show_left_steps_text = f"[{left_current} of {left_total}] "
             self.ui_show_left_steps_text_max_len = len(self.ui_show_left_steps_text)
@@ -1077,13 +1080,13 @@ class ProgressBar:
         self.bar_length = bar_length
 
         total_units = bar_length * SUBCELL_RESOLUTION
-        if self.step() >= effective_total and total_units > 0:
+        if current_step >= effective_total and total_units > 0:
             filled_units = total_units
         elif total_units > 0:
             # Keep very early progress visible by promoting tiny non-zero
             # values to the first sub-cell instead of leaving the bar empty.
-            filled_units = int((self.step() * total_units) / effective_total)
-            if 0 < self.step() < effective_total and filled_units == 0:
+            filled_units = int((current_step * total_units) / effective_total)
+            if 0 < current_step < effective_total and filled_units == 0:
                 filled_units = 1
         else:
             filled_units = 0
@@ -1094,6 +1097,8 @@ class ProgressBar:
         )
         if not supports_styling:
             bar_rendered = bar_plain
+
+        plain_width = pre_bar_size + bar_length + log_text_width + 2
 
         rendered_line = self._render_line(
             bar_plain=bar_plain,
@@ -1106,6 +1111,7 @@ class ProgressBar:
                 backend_state=backend_state,
                 style_enabled=supports_styling,
             ),
+            plain_width=plain_width,
         )
 
         self._last_rendered_line = rendered_line
@@ -1121,6 +1127,7 @@ class ProgressBar:
         bar_rendered: Optional[str] = None,
         supports_styling: bool = True,
         animate_title: Optional[bool] = None,
+        plain_width: Optional[int] = None,
     ) -> str:
         """Assemble the final visible line from title, bar, and status fields."""
 
@@ -1172,7 +1179,8 @@ class ProgressBar:
         rendered_out = ''.join(segments_rendered) if supports_styling else plain_out
 
         if columns is not None:
-            plain_width = visible_length(plain_out)
+            if plain_width is None:
+                plain_width = visible_length(plain_out)
             if plain_width > columns:
                 rendered_out = (
                     self._truncate_ansi(rendered_out, columns)

--- a/logbar/terminal.py
+++ b/logbar/terminal.py
@@ -202,10 +202,11 @@ def _is_headless_environment(*, notebook: bool = False) -> bool:
     if notebook:
         return True
 
-    env_vars = os.environ
-    for key in env_vars:
-        if key in _HEADLESS_ENV_VARS or key.startswith(_HEADLESS_ENV_PREFIXES):
-            return True
+    if any(name in os.environ for name in _HEADLESS_ENV_VARS):
+        return True
+
+    if any(key.startswith(_HEADLESS_ENV_PREFIXES) for key in os.environ):
+        return True
 
     if os.environ.get("TERM", "").strip().lower() == "dumb":
         return True
@@ -229,18 +230,16 @@ def render_backend_state(
     is_tty = _is_stream_tty(target)
 
     term_value = str(os.environ.get("TERM", "")).strip().lower()
-    force_cursor = bool(os.environ.get("LOGBAR_FORCE_TERMINAL_CURSOR", "").strip())
+    force_cursor_value = os.environ.get("LOGBAR_FORCE_TERMINAL_CURSOR", "")
+    force_cursor = bool(force_cursor_value.strip())
     force_ansi = any(
-        str(os.environ.get(name, "")).strip().lower() not in {"", "0", "false", "off", "no"}
+        _env_flag_enabled(name)
         for name in ("LOGBAR_FORCE_ANSI", "CLICOLOR_FORCE", "FORCE_COLOR")
     )
-    disable_styling = (
-        "NO_COLOR" in os.environ
-        or str(os.environ.get("ANSI_COLORS_DISABLED", "")).strip().lower() not in {"", "0", "false", "off", "no"}
-    )
+    disable_styling = "NO_COLOR" in os.environ or _env_flag_enabled("ANSI_COLORS_DISABLED")
     raw_ansi_blocked = term_value == "dumb" and not force_ansi
 
-    supports_cursor = is_tty or bool(os.environ.get("LOGBAR_FORCE_TERMINAL_CURSOR", "").strip())
+    supports_cursor = is_tty or force_cursor
     if notebook:
         supports_cursor = False
     elif force_cursor:


### PR DESCRIPTION
## Summary

Targeted micro-optimizations in the hot drawing/callback paths that showed up in `cProfile`:

- **Fast ASCII paths for ANSI/width helpers** (`drawing.py`):
  - `visible_length`, `truncate_ansi`, and `strip_ansi` now short-circuit on plain ASCII printable strings, skipping `iter_display_atoms` and regex substitution.

- **Single-field coordinator state sync** (`logbar.py`):
  - `_sync_default_coordinator_state` was doing a full `field_names()` scan on every state mutation. It now updates only the changed field when called with `name`/`value`.

- **Skip no-op progress stack renders on cursor backends** (`logbar.py`):
  - `_render_progress_stack_locked` returns early when the backend supports cursor movement, there are no active progress bars, no precomputed snapshot, and no previously drawn lines. This removes per-log stack bookkeeping in columns/logging benchmarks while still running the notebook/plain-stdout clear path for non-cursor backends.

- **Precompute line width in progress rendering** (`progress.py`):
  - `_render_snapshot` now computes `plain_width` from its existing size math and passes it into `_render_line`, avoiding a per-draw `visible_length(plain_out)` call.
  - Reuse a single `current_step` and pass `total_steps` into `calc_time`, reducing repeated `self.step()` and `len(self)` calls.

- **Faster bar rasterization** (`drawing.py` / `progress.py`):
  - `CellBarRenderer.render_units` builds the plain bar string with multiplications instead of a per-cell loop, and removes the now-unused `_cell_char` helper.
  - `ProgressStyle._bar_renderer` is cached by `units_per_cell` to avoid rebuilding the immutable renderer each draw.

- **Fewer environment lookups** (`terminal.py`):
  - `render_backend_state` reads `LOGBAR_FORCE_TERMINAL_CURSOR` and `TERM` once per call and reuses `_env_flag_enabled` for the ANSI/ styling flags.
  - `_is_headless_environment` uses explicit membership + tuple-prefix `startswith` instead of iterating all env vars and rebuilding frozenset checks per key.

## Profiling

Measured with a local `cProfile` harness (1000 iterations per API for progress snapshot / logs, 100×10 iterations for progress iteration, 120 columns):

| API | Before | After |
| --- | ------ | ----- |
| progress snapshot | 0.265 s | 0.143 s |
| progress iter | 0.352 s | 0.165 s |
| columns | 0.495 s | 0.143 s |
| logs | 0.171 s | 0.065 s |

All existing tests pass (`141 passed, 5 skipped, 5 subtests passed`).

Link to Devin session: https://app.devin.ai/sessions/45e5067b04374a8381566d710d0311da
Requested by: @Qubitium