### PR TITLE
Bump version to 0.4.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LogBar"
-version = "0.4.7"
+version = "0.4.9"
 description = "A unified Logger and ProgressBar util with zero dependencies."
 readme = "README.md"
 requires-python = ">=3"


### PR DESCRIPTION
## Summary

Bump package version from `0.4.7` to `0.4.9` to prepare a release that includes the recent drawing/callback latency improvements.

Link to Devin session: https://app.devin.ai/sessions/45e5067b04374a8381566d710d0311da
Requested by: @Qubitium