### PR TITLE
fix: prefer real terminal size over stale COLUMNS/LINES env in tmux

### DIFF
--- a/logbar/terminal.py
+++ b/logbar/terminal.py
@@ -32,7 +32,10 @@ def _stream_terminal_size(stream: Optional[object], fallback: tuple[int, int]) -
     """Query terminal size from a specific stream when it exposes `fileno()`."""
 
     target = stream if stream is not None else sys.stdout
-    fileno = getattr(target, "fileno", None)
+    try:
+        fileno = getattr(target, "fileno", None)
+    except (AttributeError, OSError, ValueError):
+        return None
     if not callable(fileno):
         return None
 
@@ -46,50 +49,63 @@ def _stream_terminal_size(stream: Optional[object], fallback: tuple[int, int]) -
 def terminal_size(fallback=(80, 24), stream: Optional[object] = None):
     """Get the size of the terminal window.
 
-    For each of the two dimensions, the environment variable, COLUMNS
-    and LINES respectively, is checked. If the variable is defined and
-    the value is a positive integer, it is used.
+    When ``stream`` reports itself as a TTY, the active terminal is queried
+    directly through its file descriptor (``os.get_terminal_size``) so that
+    stale ``COLUMNS``/``LINES`` environment variables do not override a resized
+    terminal. This matters for multiplexers such as tmux/screen, where the
+    shell may inherit an old window size.
 
-    When COLUMNS or LINES is not defined, which is the common case,
-    shutil.get_terminal_size is used to determine the current terminal size.
+    If ``stream`` is not a TTY or its file descriptor cannot be queried,
+    ``shutil.get_terminal_size`` is used. That helper will fall back to the
+    ``COLUMNS``/``LINES`` environment variables and finally to the supplied
+    fallback tuple.
 
     If the terminal size cannot be successfully queried, either because
     the system doesn't support querying, or because we are not
     connected to a terminal, the value given in fallback parameter
     is used. Fallback defaults to (80, 24) which is the default
     size used by many terminal emulators.
-
-    The value returned is a named tuple of type os.terminal_size.
     """
-    # columns, lines are the working values
+
+    target = stream if stream is not None else sys.stdout
+
+    isatty = getattr(target, "isatty", None)
+    try:
+        if callable(isatty) and not isatty():
+            pass
+        else:
+            size = _stream_terminal_size(target, fallback)
+            if size is not None:
+                return (max(0, int(size[0])), max(0, int(size[1])))
+    except (AttributeError, OSError, ValueError):
+        pass
+
+    columns = 0
+    lines = 0
     try:
         columns = int(os.environ['COLUMNS'])
     except (KeyError, ValueError):
-        columns = 0
+        pass
 
     try:
         lines = int(os.environ['LINES'])
     except (KeyError, ValueError):
-        lines = 0
+        pass
 
-    # only query if necessary
     if columns <= 0 or lines <= 0:
-        size = _stream_terminal_size(stream, fallback)
-        if size is None:
-            try:
-                queried = shutil.get_terminal_size(fallback)
-                size = (queried.columns or fallback[0], queried.lines or fallback[1])
-            except (OSError, ValueError):
-                # shutil.get_terminal_size failed because the runtime does not have an
-                # attached terminal. Fall back to the provided default which mirrors
-                # the behaviour of shutil.get_terminal_size when a fallback is supplied.
-                size = fallback
-        if columns <= 0:
-            columns = size[0] or fallback[0]
-        if lines <= 0:
-            lines = size[1] or fallback[1]
+        try:
+            queried = shutil.get_terminal_size(fallback)
+            if columns <= 0:
+                columns = queried.columns or fallback[0]
+            if lines <= 0:
+                lines = queried.lines or fallback[1]
+        except (OSError, ValueError):
+            if columns <= 0:
+                columns = fallback[0]
+            if lines <= 0:
+                lines = fallback[1]
 
-    return (columns, lines)
+    return (max(0, int(columns)), max(0, int(lines)))
 
 
 # Environment markers used by AI-agent, remote, or non-interactive runtimes.

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -111,3 +111,78 @@ class TestTerminal(unittest.TestCase):
         self.assertTrue(forced_color.supports_ansi)
         self.assertTrue(forced_color.supports_styling)
         self.assertFalse(forced_color.supports_cursor)
+
+    def test_terminal_size_prefers_tty_query_over_stale_env(self):
+        """Do not let stale COLUMNS/LINES override the real terminal size."""
+
+        class FakeTTYStream:
+            """A stream that claims to be a TTY and exposes a file descriptor."""
+
+            def isatty(self):
+                return True
+
+            def fileno(self):
+                return 17
+
+        stream = FakeTTYStream()
+
+        with mock.patch.dict(
+            "logbar.terminal.os.environ",
+            {"COLUMNS": "40", "LINES": "10"},
+            clear=True,
+        ), \
+             mock.patch(
+            "logbar.terminal.os.get_terminal_size",
+            return_value=os.terminal_size((120, 40)),
+        ), \
+             mock.patch(
+            "logbar.terminal.shutil.get_terminal_size",
+            side_effect=AssertionError("should not use shutil fallback"),
+        ):
+            columns, lines = terminal_module.terminal_size(stream=stream)
+
+        self.assertEqual((columns, lines), (120, 40))
+
+    def test_terminal_size_uses_env_when_stream_is_not_a_tty(self):
+        """Respect COLUMNS/LINES when there is no real terminal to query."""
+
+        class NonTTYStream:
+            def isatty(self):
+                return False
+
+        stream = NonTTYStream()
+
+        with mock.patch.dict(
+            "logbar.terminal.os.environ",
+            {"COLUMNS": "55", "LINES": "22"},
+            clear=True,
+        ), \
+             mock.patch(
+            "logbar.terminal.shutil.get_terminal_size",
+            return_value=os.terminal_size((80, 24)),
+        ):
+            columns, lines = terminal_module.terminal_size(stream=stream)
+
+        self.assertEqual((columns, lines), (55, 22))
+
+    def test_terminal_size_queries_stream_without_isatty(self):
+        """A stream with only ``fileno`` is still probed for its size."""
+
+        class StreamWithFilenoOnly:
+            def fileno(self):
+                return 9
+
+        stream = StreamWithFilenoOnly()
+
+        with mock.patch.dict("logbar.terminal.os.environ", {}, clear=True), \
+             mock.patch(
+            "logbar.terminal.os.get_terminal_size",
+            return_value=os.terminal_size((100, 50)),
+        ), \
+             mock.patch(
+            "logbar.terminal.shutil.get_terminal_size",
+            side_effect=AssertionError("should not use shutil fallback"),
+        ):
+            columns, lines = terminal_module.terminal_size(stream=stream)
+
+        self.assertEqual((columns, lines), (100, 50))


### PR DESCRIPTION
## Summary

Fixes a bug where LogBar used stale `COLUMNS`/`LINES` environment variables even when it could query the actual terminal size, causing rendering overflow/width math errors in tmux/screen sessions after a pane resize.

`terminal_size()` now:
1. If the supplied `stream` is a TTY (or has no `isatty` method), queries `os.get_terminal_size(fileno())` directly.
2. Falls back to `shutil.get_terminal_size()` (which in turn checks `sys.__stdout__`/`__stderr__` and the `COLUMNS`/`LINES` env) only when the stream is not a TTY or the fd query fails.

This keeps the environment-variable fallback for non-TTY/CI runs while always using the live terminal dimensions for interactive terminals.

Also hardens `_stream_terminal_size()` to catch `OSError`/`ValueError` thrown by a stream's `fileno` property (e.g. `io.StringIO.fileno`), not just by `os.get_terminal_size()`.

## Reproduction

Inside a 120x40 tmux pane with stale env:

```bash
COLUMNS=40 LINES=10 python3 -c "from logbar.terminal import terminal_size; print(terminal_size())"
# before: (40, 10)
# after:  (120, 40)
```

## Tests

- `test_terminal_size_prefers_tty_query_over_stale_env`
- `test_terminal_size_uses_env_when_stream_is_not_a_tty`
- `test_terminal_size_queries_stream_without_isatty`

All 141 tests pass locally.

Link to Devin session: https://app.devin.ai/sessions/45e5067b04374a8381566d710d0311da
Requested by: @Qubitium