### PR TITLE
Add colored symbol log-level prefixes, align table max width, and fix progress-bar tail clearing

### DIFF
--- a/logbar/columns.py
+++ b/logbar/columns.py
@@ -433,7 +433,9 @@ class ColumnsPrinter:
         slot_count = self._slot_count()
         separator_count = slot_count + 1 if slot_count else 0
 
-        available_total = max(0, term_cols - (self._level_max_length + 2))
+        # The logger reserves one trailing space after the level prefix, so the
+        # table row budget is terminal width minus the prefix, not minus two.
+        available_total = max(0, term_cols - (self._level_max_length + 1))
 
         if hint:
             if hint[0] == "percent":

--- a/logbar/columns.py
+++ b/logbar/columns.py
@@ -131,7 +131,7 @@ class ColumnsPrinter:
         padding: int = 2,
         width_hint: Optional[Union[str, int, float]] = None,
         level_enum: Any,
-        level_max_length: int,
+        level_max_length_provider: Callable[[], int],
         terminal_size_provider: Optional[Callable[[], Tuple[int, int]]] = None,
     ) -> None:
         """Create a column printer bound to a logger and initial layout hints."""
@@ -146,7 +146,7 @@ class ColumnsPrinter:
         self._target_width_hint: Optional[Tuple[str, float]] = self._parse_width_hint(width_hint)
         self._current_total_width: Optional[int] = None
         self._level_enum = level_enum
-        self._level_max_length = level_max_length
+        self._level_max_length_provider = level_max_length_provider
         self._terminal_size = terminal_size_provider or terminal_size
         self._level_proxies: Dict[Any, ColumnsPrinter._LevelProxy] = {}
         self._lock = threading.RLock()
@@ -155,6 +155,11 @@ class ColumnsPrinter:
 
         if headers:
             self._set_columns(headers)
+
+    def _get_level_max_length(self) -> int:
+        """Resolve the current level-prefix width from the logger at render time."""
+
+        return self._level_max_length_provider()
 
     @property
     def widths(self) -> List[int]:
@@ -435,7 +440,7 @@ class ColumnsPrinter:
 
         # The logger reserves one trailing space after the level prefix, so the
         # table row budget is terminal width minus the prefix, not minus two.
-        available_total = max(0, term_cols - (self._level_max_length + 1))
+        available_total = max(0, term_cols - (self._get_level_max_length() + 1))
 
         if hint:
             if hint[0] == "percent":
@@ -604,7 +609,7 @@ class ColumnsPrinter:
         if term_cols <= 0:
             term_cols = 80
         # Match the logger's prefix budget: one trailing space after the level.
-        return max(0, term_cols - (self._level_max_length + 1))
+        return max(0, term_cols - (self._get_level_max_length() + 1))
 
     def _clamp_total_width(self, max_total: Optional[int] = None) -> None:
         """Reduce slot widths so the full bordered row does not exceed `max_total`."""

--- a/logbar/columns.py
+++ b/logbar/columns.py
@@ -603,7 +603,8 @@ class ColumnsPrinter:
         term_cols, _ = self._terminal_size()
         if term_cols <= 0:
             term_cols = 80
-        return max(0, term_cols - (self._level_max_length + 2))
+        # Match the logger's prefix budget: one trailing space after the level.
+        return max(0, term_cols - (self._level_max_length + 1))
 
     def _clamp_total_width(self, max_total: Optional[int] = None) -> None:
         """Reduce slot widths so the full bordered row does not exceed `max_total`."""

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1788,7 +1788,9 @@ class LogBar(logging.Logger):
         line_length = level_width + 1 + message_width
 
         if columns > 0:
-            padding_needed = max(0, columns - level_width - 2 - message_width)
+            # The prefix already includes one trailing space, so pad only to
+            # fill the remaining terminal width.
+            padding_needed = max(0, columns - level_width - 1 - message_width)
             rendered_message = f"{str_msg}{' ' * padding_needed}"
             printable_length = columns
         else:
@@ -1810,7 +1812,10 @@ class LogBar(logging.Logger):
         )
 
         prefix = _level_prefix(level_label, backend_state.supports_ansi, use_symbol_prefix)
-        _print(f"\r{prefix}{rendered_message}", end='\n', flush=True)
+        # Clear any leftover characters from a previous longer line before
+        # moving to the next row; this keeps progress-bar tails from lingering.
+        clear_tail = "\033[K" if backend_state.supports_ansi else ""
+        _print(f"\r{prefix}{rendered_message}{clear_tail}", end='\n', flush=True)
 
         with _STATE_LOCK:
             last_rendered_length = printable_length

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1295,11 +1295,13 @@ def _terminal_supports_symbols(
 ) -> bool:
     """Best-effort check that the terminal can render colored Unicode symbols."""
 
+    if not supports_ansi:
+        # Symbols are only useful when color can differentiate log levels.
+        return False
+
     if _env_flag_enabled("LOGBAR_FORCE_SYMBOL_PREFIX"):
         return True
     if _env_flag_enabled("LOGBAR_DISABLE_SYMBOL_PREFIX"):
-        return False
-    if not supports_ansi:
         return False
 
     if stream is None:

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1272,12 +1272,14 @@ class LEVEL(str, Enum):
 
 LEVEL_MAX_LENGTH = max(len(level.value) for level in LEVEL)  # longest standard label
 
+DEFAULT_LEVEL_SYMBOL = "◼"
+
 LEVEL_SYMBOLS = {
-    "DEBUG": "■",
-    "INFO": "■",
-    "WARN": "■",
-    "ERROR": "■",
-    "CRIT": "■",
+    "DEBUG": DEFAULT_LEVEL_SYMBOL,
+    "INFO": DEFAULT_LEVEL_SYMBOL,
+    "WARN": DEFAULT_LEVEL_SYMBOL,
+    "ERROR": DEFAULT_LEVEL_SYMBOL,
+    "CRIT": DEFAULT_LEVEL_SYMBOL,
 }
 
 
@@ -1301,8 +1303,6 @@ def _terminal_supports_symbols(
 
     if _env_flag_enabled("LOGBAR_FORCE_SYMBOL_PREFIX"):
         return True
-    if _env_flag_enabled("LOGBAR_DISABLE_SYMBOL_PREFIX"):
-        return False
 
     if stream is None:
         stream = sys.stdout
@@ -1317,7 +1317,7 @@ def _level_display(level_label: str, use_symbol_prefix: bool) -> str:
     """Resolve the printable token for a level (colored symbol or text label)."""
 
     if use_symbol_prefix:
-        return LEVEL_SYMBOLS.get(level_label, level_label)
+        return LEVEL_SYMBOLS.get(level_label, DEFAULT_LEVEL_SYMBOL)
     return level_label
 
 
@@ -1666,10 +1666,14 @@ class LogBar(logging.Logger):
 
         super().setLevel(self._normalize_level(level))
 
-    def _resolve_symbol_prefix(self, supports_ansi: bool) -> bool:
+    def _resolve_symbol_prefix(self, backend_state: Optional[RenderBackendState] = None) -> bool:
         """Return whether this logger should reserve/use a one-character symbol prefix."""
 
-        return self._symbol_prefix and _terminal_supports_symbols(supports_ansi, sys.stdout)
+        if not self._symbol_prefix:
+            return False
+        if backend_state is None:
+            backend_state = _current_render_backend_state()
+        return backend_state.supports_symbols
 
     def columns(self, *headers, cols: Optional[Sequence] = None, width: Optional[Union[str, int, float]] = None, padding: int = 2):
         """Return a column-aware helper that keeps column widths aligned."""
@@ -1690,7 +1694,7 @@ class LogBar(logging.Logger):
                 header_defs = list(headers)
 
         backend_state = _current_render_backend_state()
-        use_symbol = self._resolve_symbol_prefix(backend_state.supports_ansi)
+        use_symbol = self._resolve_symbol_prefix(backend_state)
         level_max_length = _level_max_length(use_symbol)
 
         return ColumnsPrinter(
@@ -1774,7 +1778,7 @@ class LogBar(logging.Logger):
         backend_state = backend_state or _current_render_backend_state()
         columns = backend_state.columns
         terminal_rows = backend_state.lines
-        use_symbol_prefix = self._resolve_symbol_prefix(backend_state.supports_ansi)
+        use_symbol_prefix = self._resolve_symbol_prefix(backend_state)
         level_width = _level_width(level_label, use_symbol_prefix)
 
         with _STATE_LOCK:

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -148,10 +148,7 @@ def _log_headless_state_once(backend_state: Optional[RenderBackendState] = None)
         except Exception:
             return
 
-    log.info(
-        "LogBar: headless/AI-agent/notebook/CI environment detected; "
-        "high-frequency progress bars and animations are disabled."
-    )
+    log.info("LogBar: headless/CI mode; progress animations disabled.")
 
 
 def _stdout_supports_cursor_movement() -> bool:
@@ -1291,7 +1288,7 @@ LEVEL_MAX_LENGTH = max(len(level.value) for level in LEVEL)  # longest standard 
 
 LEVEL_SYMBOLS = {
     "DEBUG": "◆",
-    "INFO": "●",
+    "INFO": "⬤",
     "WARN": "▲",
     "ERROR": "■",
     "CRIT": "◉",

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -781,20 +781,6 @@ def _prepare_progress_stack_for_log_locked(backend_state: Optional[RenderBackend
     return True
 
 
-@lru_cache(maxsize=32)
-def _level_prefix(level_label: str, supports_ansi: bool) -> str:
-    """Build and cache the colored or plain log-level prefix."""
-
-    level_width = max(LEVEL_MAX_LENGTH, len(level_label))
-    level_padding = " " * (level_width - len(level_label))
-    if not supports_ansi:
-        return f"{level_label}{level_padding} "
-
-    reset = COLORS["RESET"]
-    color = COLORS.get(level_label, reset)
-    return f"{color}{level_label}{reset}{level_padding} "
-
-
 def _iter_contiguous_blocks(indexes: Sequence[int]):
     """Group sorted row indexes into contiguous rewrite blocks."""
 
@@ -1298,6 +1284,8 @@ LEVEL_SYMBOLS = {
 def _symbol_prefix_default() -> bool:
     """Return whether the colored symbol prefix should be enabled by default."""
 
+    if _env_flag_enabled("LOGBAR_FORCE_SYMBOL_PREFIX"):
+        return True
     return not _env_flag_enabled("LOGBAR_DISABLE_SYMBOL_PREFIX")
 
 
@@ -1676,6 +1664,11 @@ class LogBar(logging.Logger):
 
         super().setLevel(self._normalize_level(level))
 
+    def _resolve_symbol_prefix(self, supports_ansi: bool) -> bool:
+        """Return whether this logger should reserve/use a one-character symbol prefix."""
+
+        return self._symbol_prefix and _terminal_supports_symbols(supports_ansi, sys.stdout)
+
     def columns(self, *headers, cols: Optional[Sequence] = None, width: Optional[Union[str, int, float]] = None, padding: int = 2):
         """Return a column-aware helper that keeps column widths aligned."""
 
@@ -1695,10 +1688,7 @@ class LogBar(logging.Logger):
                 header_defs = list(headers)
 
         backend_state = _current_render_backend_state()
-        use_symbol = self._symbol_prefix and _terminal_supports_symbols(
-            backend_state.supports_ansi,
-            sys.stdout,
-        )
+        use_symbol = self._resolve_symbol_prefix(backend_state.supports_ansi)
         level_max_length = _level_max_length(use_symbol)
 
         return ColumnsPrinter(
@@ -1782,10 +1772,7 @@ class LogBar(logging.Logger):
         backend_state = backend_state or _current_render_backend_state()
         columns = backend_state.columns
         terminal_rows = backend_state.lines
-        use_symbol_prefix = self._symbol_prefix and _terminal_supports_symbols(
-            backend_state.supports_ansi,
-            sys.stdout,
-        )
+        use_symbol_prefix = self._resolve_symbol_prefix(backend_state.supports_ansi)
         level_width = _level_width(level_label, use_symbol_prefix)
 
         with _STATE_LOCK:

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1291,28 +1291,6 @@ def _symbol_prefix_default() -> bool:
     return not _env_flag_enabled("LOGBAR_DISABLE_SYMBOL_PREFIX")
 
 
-def _terminal_supports_symbols(
-    supports_ansi: bool = False,
-    stream: Optional[object] = None,
-) -> bool:
-    """Best-effort check that the terminal can render colored Unicode symbols."""
-
-    if not supports_ansi:
-        # Symbols are only useful when color can differentiate log levels.
-        return False
-
-    if _env_flag_enabled("LOGBAR_FORCE_SYMBOL_PREFIX"):
-        return True
-
-    if stream is None:
-        stream = sys.stdout
-    isatty = getattr(stream, "isatty", None)
-    try:
-        return bool(isatty())
-    except Exception:
-        return False
-
-
 def _level_display(level_label: str, use_symbol_prefix: bool) -> str:
     """Resolve the printable token for a level (colored symbol or text label)."""
 
@@ -1812,10 +1790,10 @@ class LogBar(logging.Logger):
         )
 
         prefix = _level_prefix(level_label, backend_state.supports_ansi, use_symbol_prefix)
-        # Clear any leftover characters from a previous longer line before
-        # moving to the next row; this keeps progress-bar tails from lingering.
-        clear_tail = "\033[K" if backend_state.supports_ansi else ""
-        _print(f"\r{prefix}{rendered_message}{clear_tail}", end='\n', flush=True)
+        # Clear the entire line before writing so characters from a previous
+        # longer line (e.g. progress-bar tails) do not linger.
+        clear_line = "\033[2K" if backend_state.supports_ansi else ""
+        _print(f"\r{clear_line}{prefix}{rendered_message}", end='\n', flush=True)
 
         with _STATE_LOCK:
             last_rendered_length = printable_length

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1287,11 +1287,11 @@ class LEVEL(str, Enum):
 LEVEL_MAX_LENGTH = max(len(level.value) for level in LEVEL)  # longest standard label
 
 LEVEL_SYMBOLS = {
-    "DEBUG": "◆",
-    "INFO": "⬤",
-    "WARN": "▲",
+    "DEBUG": "■",
+    "INFO": "■",
+    "WARN": "■",
     "ERROR": "■",
-    "CRIT": "◉",
+    "CRIT": "■",
 }
 
 

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1671,9 +1671,10 @@ class LogBar(logging.Logger):
             else:
                 header_defs = list(headers)
 
-        backend_state = _current_render_backend_state()
-        use_symbol = self._resolve_symbol_prefix(backend_state)
-        level_max_length = _level_max_length(use_symbol)
+        def _level_max_length_provider() -> int:
+            """Resolve the current prefix width from the logger at render time."""
+
+            return _level_max_length(self._resolve_symbol_prefix())
 
         return ColumnsPrinter(
             logger=self,
@@ -1681,7 +1682,7 @@ class LogBar(logging.Logger):
             padding=padding,
             width_hint=width,
             level_enum=LEVEL,
-            level_max_length=level_max_length,
+            level_max_length_provider=_level_max_length_provider,
             terminal_size_provider=lambda: terminal_size(),
         )
 

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -14,7 +14,12 @@ from enum import Enum
 from functools import lru_cache, wraps
 from typing import Iterable, Optional, Sequence, Union, TYPE_CHECKING
 
-from .terminal import RenderBackendState, render_backend_state, terminal_size
+from .terminal import (
+    RenderBackendState,
+    _env_flag_enabled,
+    render_backend_state,
+    terminal_size,
+)
 from .columns import ColumnSpec, ColumnsPrinter
 from .buffer import get_buffered_stdout
 from .coordinator import RenderCoordinator
@@ -1282,7 +1287,86 @@ class LEVEL(str, Enum):
     ERROR = "ERROR"
     CRITICAL = "CRIT"
 
-LEVEL_MAX_LENGTH = 5 # ERROR/DEBUG is longest at 5 chars
+LEVEL_MAX_LENGTH = max(len(level.value) for level in LEVEL)  # longest standard label
+
+LEVEL_SYMBOLS = {
+    "DEBUG": "◆",
+    "INFO": "●",
+    "WARN": "▲",
+    "ERROR": "■",
+    "CRIT": "◉",
+}
+
+
+def _symbol_prefix_default() -> bool:
+    """Return whether the colored symbol prefix should be enabled by default."""
+
+    return not _env_flag_enabled("LOGBAR_DISABLE_SYMBOL_PREFIX")
+
+
+def _terminal_supports_symbols(
+    supports_ansi: bool = False,
+    stream: Optional[object] = None,
+) -> bool:
+    """Best-effort check that the terminal can render colored Unicode symbols."""
+
+    if _env_flag_enabled("LOGBAR_FORCE_SYMBOL_PREFIX"):
+        return True
+    if _env_flag_enabled("LOGBAR_DISABLE_SYMBOL_PREFIX"):
+        return False
+    if not supports_ansi:
+        return False
+
+    if stream is None:
+        stream = sys.stdout
+    isatty = getattr(stream, "isatty", None)
+    try:
+        return bool(isatty())
+    except Exception:
+        return False
+
+
+def _level_display(level_label: str, use_symbol_prefix: bool) -> str:
+    """Resolve the printable token for a level (colored symbol or text label)."""
+
+    if use_symbol_prefix:
+        return LEVEL_SYMBOLS.get(level_label, level_label)
+    return level_label
+
+
+def _level_width(level_label: str, use_symbol_prefix: bool) -> int:
+    """Return the visible width of a log-level prefix before the trailing space."""
+
+    display = _level_display(level_label, use_symbol_prefix)
+    display_width = visible_length(display)
+    if use_symbol_prefix:
+        return max(1, display_width)
+    return max(LEVEL_MAX_LENGTH, display_width)
+
+
+def _level_max_length(use_symbol_prefix: bool) -> int:
+    """Return the widest prefix a table must reserve across all log levels."""
+
+    if use_symbol_prefix:
+        return max(1, max(visible_length(s) for s in LEVEL_SYMBOLS.values()))
+    return LEVEL_MAX_LENGTH
+
+
+@lru_cache(maxsize=64)
+def _level_prefix(level_label: str, supports_ansi: bool, use_symbol_prefix: bool = False) -> str:
+    """Build and cache the colored symbol or colored text log-level prefix."""
+
+    display = _level_display(level_label, use_symbol_prefix)
+    level_width = _level_width(level_label, use_symbol_prefix)
+    display_width = visible_length(display)
+    level_padding = " " * (level_width - display_width)
+
+    if not supports_ansi:
+        return f"{display}{level_padding} "
+
+    color = COLORS.get(level_label, COLORS["RESET"])
+    return f"{color}{display}{COLORS['RESET']}{level_padding} "
+
 
 LEVEL_TO_LOGGING = {
     LEVEL.DEBUG: logging.DEBUG,
@@ -1532,6 +1616,13 @@ class LogBar(logging.Logger):
 
         self.history = set()
         self._history_lock = threading.Lock()
+        self._symbol_prefix = _symbol_prefix_default()
+
+    def set_symbol_prefix(self, enabled: bool = True) -> "LogBar":
+        """Enable or disable colored symbol prefixes in favor of colored text."""
+
+        self._symbol_prefix = bool(enabled)
+        return self
 
     def _normalize_level(self, level: Union[LEVEL, int, str]) -> int:
         """Normalize enum, string, or numeric levels to stdlib integers."""
@@ -1606,13 +1697,20 @@ class LogBar(logging.Logger):
             else:
                 header_defs = list(headers)
 
+        backend_state = _current_render_backend_state()
+        use_symbol = self._symbol_prefix and _terminal_supports_symbols(
+            backend_state.supports_ansi,
+            sys.stdout,
+        )
+        level_max_length = _level_max_length(use_symbol)
+
         return ColumnsPrinter(
             logger=self,
             headers=header_defs,
             padding=padding,
             width_hint=width,
             level_enum=LEVEL,
-            level_max_length=LEVEL_MAX_LENGTH,
+            level_max_length=level_max_length,
             terminal_size_provider=lambda: terminal_size(),
         )
 
@@ -1687,7 +1785,11 @@ class LogBar(logging.Logger):
         backend_state = backend_state or _current_render_backend_state()
         columns = backend_state.columns
         terminal_rows = backend_state.lines
-        level_width = max(LEVEL_MAX_LENGTH, len(level_label))
+        use_symbol_prefix = self._symbol_prefix and _terminal_supports_symbols(
+            backend_state.supports_ansi,
+            sys.stdout,
+        )
+        level_width = _level_width(level_label, use_symbol_prefix)
 
         with _STATE_LOCK:
             previous_render_length = last_rendered_length
@@ -1717,7 +1819,7 @@ class LogBar(logging.Logger):
             backend_state=backend_state,
         )
 
-        prefix = _level_prefix(level_label, backend_state.supports_ansi)
+        prefix = _level_prefix(level_label, backend_state.supports_ansi, use_symbol_prefix)
         _print(f"\r{prefix}{rendered_message}", end='\n', flush=True)
 
         with _STATE_LOCK:

--- a/logbar/logbar.py
+++ b/logbar/logbar.py
@@ -1329,7 +1329,9 @@ def _level_prefix(level_label: str, supports_ansi: bool, use_symbol_prefix: bool
     if not supports_ansi:
         return f"{display}{level_padding} "
 
-    color = COLORS.get(level_label, COLORS["RESET"])
+    # Unknown labels in symbol mode get the INFO color so the glyph is visible.
+    default_color = COLORS["INFO"] if use_symbol_prefix else COLORS["RESET"]
+    color = COLORS.get(level_label, default_color)
     return f"{color}{display}{COLORS['RESET']}{level_padding} "
 
 
@@ -1768,7 +1770,8 @@ class LogBar(logging.Logger):
 
         if columns > 0:
             # The prefix already includes one trailing space, so pad only to
-            # fill the remaining terminal width.
+            # fill the remaining terminal width. \033[2K before writing clears
+            # any leftover characters from a previous longer line.
             padding_needed = max(0, columns - level_width - 1 - message_width)
             rendered_message = f"{str_msg}{' ' * padding_needed}"
             printable_length = columns

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -1076,7 +1076,10 @@ class ProgressBar:
         if not self._attached or render_fn is None:
             with context:
                 try:
-                    print(f'\r{rendered_line}', end='', flush=True)
+                    # Erase any trailing characters left from a previous,
+                    # longer inline frame before printing the new one.
+                    clear_tail = "\033[K" if backend_state.supports_ansi else ""
+                    print(f'\r{rendered_line}{clear_tail}', end='', flush=True)
                 except Exception:
                     if not sys.is_finalizing():
                         raise

--- a/logbar/progress.py
+++ b/logbar/progress.py
@@ -1076,10 +1076,10 @@ class ProgressBar:
         if not self._attached or render_fn is None:
             with context:
                 try:
-                    # Erase any trailing characters left from a previous,
-                    # longer inline frame before printing the new one.
-                    clear_tail = "\033[K" if backend_state.supports_ansi else ""
-                    print(f'\r{rendered_line}{clear_tail}', end='', flush=True)
+                    # Clear the whole line before drawing the new inline frame
+                    # so characters from a previous longer frame do not linger.
+                    clear_line = "\033[2K" if backend_state.supports_ansi else ""
+                    print(f'\r{clear_line}{rendered_line}', end='', flush=True)
                 except Exception:
                     if not sys.is_finalizing():
                         raise

--- a/logbar/region_logger.py
+++ b/logbar/region_logger.py
@@ -11,7 +11,7 @@ import sys
 
 from typing import Callable, Optional, Sequence, Union
 
-from .logbar import LEVEL, LogBar, _RENDER_LOCK, _level_prefix, _terminal_supports_symbols
+from .logbar import LEVEL, LogBar, _RENDER_LOCK, _level_prefix
 from .region import LogRegion
 
 
@@ -47,13 +47,10 @@ class RegionLogBar(LogBar):
 
         return self._supports_ansi
 
-    def _resolve_symbol_prefix(self, supports_ansi: bool) -> bool:
+    def _resolve_symbol_prefix(self, backend_state=None) -> bool:
         """Resolve symbol mode from this region's own ANSI capability."""
 
-        return self._symbol_prefix and _terminal_supports_symbols(
-            self._supports_ansi,
-            sys.stdout,
-        )
+        return self._symbol_prefix and self._supports_ansi
 
     def set_on_change(self, callback: Optional[Callable[["RegionLogBar"], None]]) -> "RegionLogBar":
         """Install or remove the callback invoked after region mutations."""
@@ -142,7 +139,7 @@ class RegionLogBar(LogBar):
 
         del normalized_level, allow_defer, backend_state
 
-        use_symbol_prefix = self._resolve_symbol_prefix(self._supports_ansi)
+        use_symbol_prefix = self._resolve_symbol_prefix()
         prefix = _level_prefix(level_label, self._supports_ansi, use_symbol_prefix)
         message_lines = str(str_msg).splitlines() or [""]
         for line in message_lines:

--- a/logbar/region_logger.py
+++ b/logbar/region_logger.py
@@ -47,6 +47,14 @@ class RegionLogBar(LogBar):
 
         return self._supports_ansi
 
+    def _resolve_symbol_prefix(self, supports_ansi: bool) -> bool:
+        """Resolve symbol mode from this region's own ANSI capability."""
+
+        return self._symbol_prefix and _terminal_supports_symbols(
+            self._supports_ansi,
+            sys.stdout,
+        )
+
     def set_on_change(self, callback: Optional[Callable[["RegionLogBar"], None]]) -> "RegionLogBar":
         """Install or remove the callback invoked after region mutations."""
 
@@ -134,7 +142,7 @@ class RegionLogBar(LogBar):
 
         del normalized_level, allow_defer, backend_state
 
-        use_symbol_prefix = self._symbol_prefix and _terminal_supports_symbols(self._supports_ansi, sys.stdout)
+        use_symbol_prefix = self._resolve_symbol_prefix(self._supports_ansi)
         prefix = _level_prefix(level_label, self._supports_ansi, use_symbol_prefix)
         message_lines = str(str_msg).splitlines() or [""]
         for line in message_lines:

--- a/logbar/region_logger.py
+++ b/logbar/region_logger.py
@@ -46,7 +46,12 @@ class RegionLogBar(LogBar):
         return self._supports_ansi
 
     def _resolve_symbol_prefix(self, backend_state=None) -> bool:
-        """Resolve symbol mode from this region's own ANSI capability."""
+        """Resolve symbol mode from this region's own ANSI capability.
+
+        Region output is not tied to process ``sys.stdout``; the screen/host
+        that renders the region decides ANSI support.  The ``backend_state``
+        parameter is accepted for signature compatibility but ignored here.
+        """
 
         return self._symbol_prefix and self._supports_ansi
 

--- a/logbar/region_logger.py
+++ b/logbar/region_logger.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-import sys
-
 from typing import Callable, Optional, Sequence, Union
 
 from .logbar import LEVEL, LogBar, _RENDER_LOCK, _level_prefix

--- a/logbar/region_logger.py
+++ b/logbar/region_logger.py
@@ -7,9 +7,11 @@
 
 from __future__ import annotations
 
+import sys
+
 from typing import Callable, Optional, Sequence, Union
 
-from .logbar import LEVEL, LogBar, _RENDER_LOCK, _level_prefix
+from .logbar import LEVEL, LogBar, _RENDER_LOCK, _level_prefix, _terminal_supports_symbols
 from .region import LogRegion
 
 
@@ -132,7 +134,8 @@ class RegionLogBar(LogBar):
 
         del normalized_level, allow_defer, backend_state
 
-        prefix = _level_prefix(level_label, self._supports_ansi)
+        use_symbol_prefix = self._symbol_prefix and _terminal_supports_symbols(self._supports_ansi, sys.stdout)
+        prefix = _level_prefix(level_label, self._supports_ansi, use_symbol_prefix)
         message_lines = str(str_msg).splitlines() or [""]
         for line in message_lines:
             self._region.append_body_line(f"{prefix}{line}")

--- a/logbar/terminal.py
+++ b/logbar/terminal.py
@@ -25,6 +25,7 @@ class RenderBackendState:
     supports_cursor: bool
     supports_ansi: bool
     supports_styling: bool
+    supports_symbols: bool = False
     headless: bool = False
 
 
@@ -286,6 +287,16 @@ def render_backend_state(
         if not force_ansi:
             supports_ansi = False
             supports_styling = False
+        # Notebooks always render through the notebook path and do not use
+        # terminal styling/cursor state, even when a force-color flag is set.
+        if notebook:
+            supports_styling = False
+
+    # Symbol prefixes require color support plus either a real TTY or an
+    # explicit force flag; they are not a notebook concept.
+    supports_symbols = supports_ansi and (
+        _env_flag_enabled("LOGBAR_FORCE_SYMBOL_PREFIX") or _is_stream_tty(target)
+    )
 
     return RenderBackendState(
         columns=max(0, int(columns)),
@@ -295,5 +306,6 @@ def render_backend_state(
         supports_cursor=supports_cursor,
         supports_ansi=supports_ansi,
         supports_styling=supports_styling,
+        supports_symbols=supports_symbols,
         headless=headless,
     )

--- a/logbar/terminal.py
+++ b/logbar/terminal.py
@@ -279,12 +279,13 @@ def render_backend_state(
 
     headless = _is_headless_environment(notebook=notebook)
 
-    # A headless backend should never claim cursor/ANSI support; the flag is
-    # the canonical signal used by the rest of the renderer to suppress draws.
+    # A headless backend should never claim cursor support. ANSI color and
+    # styling are still honored when the user explicitly forces them.
     if headless:
         supports_cursor = False
-        supports_ansi = False
-        supports_styling = False
+        if not force_ansi:
+            supports_ansi = False
+            supports_styling = False
 
     return RenderBackendState(
         columns=max(0, int(columns)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LogBar"
-version = "0.4.10"
+version = "0.4.11"
 description = "A unified Logger and ProgressBar util with zero dependencies."
 readme = "README.md"
 requires-python = ">=3"

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -235,7 +235,9 @@ def test_columns_respects_available_width():
     header_line = header_lines[0]
 
     row_segment = header_line[header_line.index('|'):]
-    expected = columns - (cols._level_max_length + 2)
+    # The logger reserves one trailing space after the level prefix, so the
+    # row budget is terminal width minus the prefix.
+    expected = columns - (cols._level_max_length + 1)
     segment_len = len(row_segment)
     content_segment = row_segment[: row_segment.rfind('|') + 1]
     slot_widths = cols.widths

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -237,7 +237,7 @@ def test_columns_respects_available_width():
     row_segment = header_line[header_line.index('|'):]
     # The logger reserves one trailing space after the level prefix, so the
     # row budget is terminal width minus the prefix.
-    expected = columns - (cols._level_max_length + 1)
+    expected = columns - (cols._get_level_max_length() + 1)
     segment_len = len(row_segment)
     content_segment = row_segment[: row_segment.rfind('|') + 1]
     slot_widths = cols.widths

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -96,6 +96,25 @@ class TestHeadlessDetection(unittest.TestCase):
         with patch.dict("logbar.terminal.os.environ", {"TERM": "dumb"}, clear=True):
             self.assertTrue(_is_headless_environment())
 
+    def test_headless_honors_force_ansi(self):
+        """``LOGBAR_FORCE_ANSI=1`` still enables ANSI color in headless backends."""
+
+        class NonTTYStream:
+            def isatty(self):
+                return False
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"CI": "1", "LOGBAR_FORCE_ANSI": "1"},
+            clear=True,
+        ):
+            state = render_backend_state(stream=NonTTYStream(), size_provider=lambda: (80, 24))
+
+        self.assertTrue(state.headless)
+        self.assertTrue(state.supports_ansi)
+        self.assertTrue(state.supports_styling)
+        self.assertFalse(state.supports_cursor)
+
     def test_notebook_backend_is_headless(self):
         """The backend state reports ``headless=True`` for notebook targets."""
 
@@ -190,7 +209,7 @@ log = LogBar.shared()
 log = LogBar.shared()  # second call should be idempotent
 out = sys.stdout.getvalue()
 # The single log line should appear exactly once.
-print("COUNT", out.count("high-frequency progress bars"), file=sys.stderr)
+print("COUNT", out.count("headless/CI mode"), file=sys.stderr)
 """
         env = {
             "PATH": os.environ.get("PATH", ""),

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -118,11 +118,28 @@ class TestHeadlessDetection(unittest.TestCase):
     def test_notebook_backend_is_headless(self):
         """The backend state reports ``headless=True`` for notebook targets."""
 
-        state = render_backend_state(notebook=True)
+        with patch.dict("logbar.terminal.os.environ", {}, clear=True):
+            state = render_backend_state(notebook=True)
         self.assertTrue(state.headless)
         self.assertFalse(state.supports_cursor)
         self.assertFalse(state.supports_ansi)
         self.assertFalse(state.supports_styling)
+        self.assertFalse(state.supports_symbols)
+
+    def test_notebook_backend_ignores_force_color_for_styling(self):
+        """Notebooks do not claim terminal styling support even with FORCE_COLOR set."""
+
+        with patch.dict(
+            "logbar.terminal.os.environ",
+            {"FORCE_COLOR": "1"},
+            clear=True,
+        ):
+            state = render_backend_state(notebook=True)
+
+        self.assertTrue(state.headless)
+        self.assertFalse(state.supports_ansi)
+        self.assertFalse(state.supports_styling)
+        self.assertFalse(state.supports_cursor)
 
     def test_plain_terminal_is_not_headless(self):
         """A clean, non-CI, non-agent environment is not headless."""

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -182,8 +182,8 @@ class TestProgressBar(unittest.TestCase):
         last_line = lines[-1]
         # The visible line (prefix + message + padding) must span the full width.
         self.assertEqual(len(last_line), columns)
-        # ANSI-enabled output should erase any leftover characters before newline.
-        self.assertIn("\033[K", raw)
+        # ANSI-enabled output clears the whole line before writing.
+        self.assertIn("\033[2K", raw)
 
     def test_percent_formatting(self):
         """Support classic printf-style formatting with one positional arg."""
@@ -428,7 +428,7 @@ class TestProgressBar(unittest.TestCase):
                 log.info("message above stack")
 
             delta = buffer.getvalue()[checkpoint:]
-            self.assertNotIn("\033[2K", delta)
+            self.assertIn("\033[2K", delta)
             self.assertIn("\033[1S", delta)
             self.assertNotIn("\033[1L", delta)
             self.assertIn(rows[0].line.ljust(columns), ANSI_ESCAPE_RE.sub('', delta))

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -165,6 +165,26 @@ class TestProgressBar(unittest.TestCase):
         self.assertIn("plain stream log", output)
         self.assertNotIn("\033[", output)
 
+    def test_log_line_fills_terminal_width_with_ansi(self):
+        """Pad emitted log lines to the terminal width and clear the rest of the line."""
+
+        columns = 80
+        stdout = io.StringIO()
+
+        with mock.patch('sys.stdout', stdout), \
+             mock.patch('logbar.logbar.terminal_size', return_value=(columns, 24)), \
+             mock.patch.dict('logbar.terminal.os.environ', {"LOGBAR_FORCE_ANSI": "1"}, clear=True):
+            log.info("fill width")
+
+        raw = stdout.getvalue()
+        lines = extract_rendered_lines(raw)
+        self.assertTrue(lines)
+        last_line = lines[-1]
+        # The visible line (prefix + message + padding) must span the full width.
+        self.assertEqual(len(last_line), columns)
+        # ANSI-enabled output should erase any leftover characters before newline.
+        self.assertIn("\033[K", raw)
+
     def test_percent_formatting(self):
         """Support classic printf-style formatting with one positional arg."""
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -199,6 +199,6 @@ class TestRegionScreen(unittest.TestCase):
 
         rows = screen.render()
 
-        self.assertEqual(rows, ["INFO  hello         "])
-        self.assertEqual(stream.getvalue(), "INFO  hello         \n")
+        self.assertEqual(rows, ["◼ hello             "])
+        self.assertEqual(stream.getvalue(), "◼ hello             \n")
         self.assertNotIn("\033[", stream.getvalue())

--- a/tests/test_symbol_prefix.py
+++ b/tests/test_symbol_prefix.py
@@ -17,8 +17,8 @@ from logbar.logbar import (
     _level_prefix,
     _level_width,
     _symbol_prefix_default,
-    _terminal_supports_symbols,
 )
+from logbar.terminal import render_backend_state
 
 
 class TestSymbolPrefix(unittest.TestCase):
@@ -62,31 +62,38 @@ class TestSymbolPrefix(unittest.TestCase):
         env = {
             "LOGBAR_DISABLE_SYMBOL_PREFIX": "1",
             "LOGBAR_FORCE_SYMBOL_PREFIX": "1",
+            "LOGBAR_FORCE_ANSI": "1",
         }
         fake_stream = mock.Mock(isatty=mock.Mock(return_value=False))
         with mock.patch.dict(os.environ, env, clear=True):
-            self.assertTrue(
-                _terminal_supports_symbols(supports_ansi=True, stream=fake_stream)
+            state = render_backend_state(
+                stream=fake_stream, size_provider=lambda: (80, 24)
             )
+        self.assertTrue(state.supports_symbols)
 
     def test_force_symbol_prefix_requires_color(self):
         """LOGBAR_FORCE_SYMBOL_PREFIX does not emit symbols without ANSI color support."""
 
-        fake_stream = mock.Mock(isatty=mock.Mock(return_value=True))
+        fake_stream = mock.Mock(isatty=mock.Mock(return_value=False))
         with mock.patch.dict(
             os.environ,
             {"LOGBAR_FORCE_SYMBOL_PREFIX": "1"},
             clear=True,
         ):
-            self.assertFalse(
-                _terminal_supports_symbols(supports_ansi=False, stream=fake_stream)
+            state = render_backend_state(
+                stream=fake_stream, size_provider=lambda: (80, 24)
             )
+        self.assertFalse(state.supports_symbols)
 
-    def test_terminal_supports_symbols_requires_ansi(self):
+    def test_symbol_prefix_requires_ansi(self):
         """Symbol prefixes are not used when ANSI colors are unavailable."""
 
-        fake_stream = mock.Mock(isatty=mock.Mock(return_value=True))
-        self.assertFalse(_terminal_supports_symbols(supports_ansi=False, stream=fake_stream))
+        fake_stream = mock.Mock(isatty=mock.Mock(return_value=False))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            state = render_backend_state(
+                stream=fake_stream, size_provider=lambda: (80, 24)
+            )
+        self.assertFalse(state.supports_symbols)
 
     def test_set_symbol_prefix_changes_behavior(self):
         """LogBar.set_symbol_prefix toggles the symbol-prefix mode."""

--- a/tests/test_symbol_prefix.py
+++ b/tests/test_symbol_prefix.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Coverage for the optional colored symbol log-level prefix feature."""
+
+import os
+import unittest
+from unittest import mock
+
+from logbar import LogBar
+from logbar.logbar import (
+    LEVEL,
+    LEVEL_SYMBOLS,
+    _level_max_length,
+    _level_prefix,
+    _level_width,
+    _symbol_prefix_default,
+    _terminal_supports_symbols,
+)
+
+
+class TestSymbolPrefix(unittest.TestCase):
+    """Verify colored symbol prefixes and the text/symbol toggle."""
+
+    def test_all_standard_levels_have_symbol(self):
+        """Every standard level label has a corresponding colored symbol."""
+
+        for level in LEVEL:
+            self.assertIn(level.value, LEVEL_SYMBOLS)
+
+    def test_symbol_prefix_is_shorter_than_text(self):
+        """Symbol prefixes render using fewer visible columns than text."""
+
+        for level in LEVEL:
+            text_prefix = _level_prefix(level.value, True, False)
+            sym_prefix = _level_prefix(level.value, True, True)
+            self.assertTrue(len(sym_prefix) < len(text_prefix))
+
+    def test_level_width_for_symbol_is_one(self):
+        """Symbol prefixes reserve one visible column before the trailing space."""
+
+        for level in LEVEL:
+            self.assertEqual(_level_width(level.value, True), 1)
+
+    def test_level_max_length_matches_mode(self):
+        """Table width budget uses 1 for symbols and the longest text label otherwise."""
+
+        self.assertEqual(_level_max_length(False), max(len(level.value) for level in LEVEL))
+        self.assertEqual(_level_max_length(True), 1)
+
+    def test_disable_symbol_prefix_env(self):
+        """LOGBAR_DISABLE_SYMBOL_PREFIX defaults the toggle to disabled."""
+
+        with mock.patch.dict(os.environ, {"LOGBAR_DISABLE_SYMBOL_PREFIX": "1"}, clear=True):
+            self.assertFalse(_symbol_prefix_default())
+
+    def test_force_symbol_prefix_overrides_disable(self):
+        """LOGBAR_FORCE_SYMBOL_PREFIX wins over the disable flag."""
+
+        env = {
+            "LOGBAR_DISABLE_SYMBOL_PREFIX": "1",
+            "LOGBAR_FORCE_SYMBOL_PREFIX": "1",
+        }
+        fake_stream = mock.Mock(isatty=mock.Mock(return_value=False))
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertTrue(
+                _terminal_supports_symbols(supports_ansi=True, stream=fake_stream)
+            )
+
+    def test_terminal_supports_symbols_requires_ansi(self):
+        """Symbol prefixes are not used when ANSI colors are unavailable."""
+
+        fake_stream = mock.Mock(isatty=mock.Mock(return_value=True))
+        self.assertFalse(_terminal_supports_symbols(supports_ansi=False, stream=fake_stream))
+
+    def test_set_symbol_prefix_changes_behavior(self):
+        """LogBar.set_symbol_prefix toggles the symbol-prefix mode."""
+
+        log = LogBar("test_set_symbol_prefix_changes_behavior")
+        self.assertTrue(log._symbol_prefix)
+        log.set_symbol_prefix(False)
+        self.assertFalse(log._symbol_prefix)
+        log.set_symbol_prefix(True)
+        self.assertTrue(log._symbol_prefix)

--- a/tests/test_symbol_prefix.py
+++ b/tests/test_symbol_prefix.py
@@ -57,7 +57,7 @@ class TestSymbolPrefix(unittest.TestCase):
             self.assertFalse(_symbol_prefix_default())
 
     def test_force_symbol_prefix_overrides_disable(self):
-        """LOGBAR_FORCE_SYMBOL_PREFIX wins over the disable flag."""
+        """LOGBAR_FORCE_SYMBOL_PREFIX wins over the disable flag when color is available."""
 
         env = {
             "LOGBAR_DISABLE_SYMBOL_PREFIX": "1",
@@ -67,6 +67,19 @@ class TestSymbolPrefix(unittest.TestCase):
         with mock.patch.dict(os.environ, env, clear=True):
             self.assertTrue(
                 _terminal_supports_symbols(supports_ansi=True, stream=fake_stream)
+            )
+
+    def test_force_symbol_prefix_requires_color(self):
+        """LOGBAR_FORCE_SYMBOL_PREFIX does not emit symbols without ANSI color support."""
+
+        fake_stream = mock.Mock(isatty=mock.Mock(return_value=True))
+        with mock.patch.dict(
+            os.environ,
+            {"LOGBAR_FORCE_SYMBOL_PREFIX": "1"},
+            clear=True,
+        ):
+            self.assertFalse(
+                _terminal_supports_symbols(supports_ansi=False, stream=fake_stream)
             )
 
     def test_terminal_supports_symbols_requires_ansi(self):


### PR DESCRIPTION
## Summary

This PR adds a default colored-symbol log-level prefix, aligns the `ColumnsPrinter` table budget with the logger, and fixes a render-buffer bug where progress-bar tails could linger on subsequent log lines.

### Colored symbol prefix (default on)

All log levels render as a single colored square (`◼`) when the terminal supports ANSI color and is a TTY. The color still matches the level:

```python
DEBUG →  \x1b[36m◼\x1b[0m
INFO  →  \x1b[32m◼\x1b[0m
WARN  →  \x1b[33m◼\x1b[0m
ERROR →  \x1b[31m◼\x1b[0m
CRIT  →  \x1b[31m◼\x1b[0m
```

If the terminal does not support colors or symbols, the renderer falls back to the existing colored text prefix (`INFO`, `DEBUG`, etc.). Users can keep text prefixes with `log.set_symbol_prefix(False)` or `LOGBAR_DISABLE_SYMBOL_PREFIX=1`, and force symbols with `LOGBAR_FORCE_SYMBOL_PREFIX=1`.

`LOGBAR_FORCE_SYMBOL_PREFIX` only bypasses the TTY check; it still requires ANSI color support so that levels remain distinguishable. To get colored symbols in a non-TTY/headless environment, pair it with `LOGBAR_FORCE_ANSI=1`.

### Table width alignment

`ColumnsPrinter` now uses the same level-prefix budget as `LogBar` in both `_get_target_width` and `_row_width_budget`:

- symbol mode: `level_max_length = 1`
- text mode: `level_max_length = max(len(level.value) for level in LEVEL)`

This fixes the case where the table row was one column narrower than the logger/progressbar line.

### Progress-bar tail clearing

- `_emit_log_line_locked` clears the whole line with `\033[2K` before printing, so characters from a previous longer line (e.g. progress-bar tails) do not linger.
- `ProgressBar.draw` also uses `\033[2K` before inline frames so shorter redraws clear leftover characters from the previous frame.

### Symbol capability source of truth

Symbol support is computed once in `RenderBackendState` and consumed via `LogBar._resolve_symbol_prefix(backend_state)`. The duplicate `_terminal_supports_symbols` helper and the unused `sys` import in `region_logger.py` have been removed.

### RegionLogBar consistency

`RegionLogBar` resolves symbol mode from its own `supports_ansi` flag instead of `sys.stdout`, so `columns()` and `_emit_log_line_locked()` reserve and print the same prefix width.

### ANSI/color detection in headless environments

`LOGBAR_FORCE_ANSI`, `CLICOLOR_FORCE`, and `FORCE_COLOR` correctly enable ANSI color even when LogBar detects a headless/CI/agent backend. Cursor support and progress animations remain suppressed in headless mode, and `NO_COLOR` still wins over any force flag. Notebook backends always report `supports_styling=False` and `supports_symbols=False`.

### Version

Bumped `pyproject.toml` to `0.4.11`.

### Tests

- `tests/test_symbol_prefix.py` covers the symbol map, prefix length, `level_max_length`, environment overrides, `LogBar.set_symbol_prefix()`, and `RenderBackendState.supports_symbols`.
- `tests/test_headless.py` verifies that `LOGBAR_FORCE_ANSI=1` enables `supports_ansi` while preserving `headless=True` and `supports_cursor=False`, and that notebook backends ignore force-color flags for styling/symbols.
- `tests/test_columns.py` asserts the table row budget now matches the logger prefix width.
- `tests/test_log.py` includes a regression test for full-width log lines and the `\033[2K` clear sequence.

Link to Devin session: https://app.devin.ai/sessions/c0924c3ae9da4b0cb1d2cb6bf580b841
Requested by: @Qubitium