### PR TITLE
fix: add setup.py fallback for legacy setuptools to resolve UNKNOWN metadata warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.4.11"
 description = "A unified Logger and ProgressBar util with zero dependencies."
 readme = "README.md"
 requires-python = ">=3"
-license = { text = "Apache-2.0" }
+dynamic = ["license"]
 authors = [
     { name = "ModelCloud", email = "qubitium@modelcloud.ai" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77.0.1,<83"]
+requires = ["setuptools>=61,<83"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ version = "0.4.11"
 description = "A unified Logger and ProgressBar util with zero dependencies."
 readme = "README.md"
 requires-python = ">=3"
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 authors = [
     { name = "ModelCloud", email = "qubitium@modelcloud.ai" }
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="LogBar",
+    version="0.4.11",
+    description="A unified Logger and ProgressBar util with zero dependencies.",
+    long_description=open("README.md", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
+    author="ModelCloud",
+    author_email="qubitium@modelcloud.ai",
+    url="https://github.com/ModelCloud/LogBar",
+    license="Apache-2.0",
+    packages=find_packages(exclude=["tests*", "test*"]),
+    python_requires=">=3",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    keywords="logger logging progressbar progress bar cli terminal lightweight zero dependency tqdm tabulate",
+)


### PR DESCRIPTION
## Summary

`pip install logbar` (and `pip install PyPcre logbar datasets`) was emitting repeated `WARNING: Generating metadata for package logbar produced metadata for project name unknown` warnings when the build ran against legacy `setuptools` that could not read `pyproject.toml` `[project]` metadata (e.g. system `setuptools` 59.6 on Ubuntu 22.04 or `no-build-isolation` installs). Without a `setup.py` fallback, the metadata came back as `UNKNOWN`, causing pip to discard each candidate version.

## Changes

- Added `setup.py` with the canonical `LogBar` metadata (`name`, `version`, `license`, `packages`, `python_requires`, etc.) so legacy `setuptools` can build the package correctly even when it does not parse `pyproject.toml`.
- Marked `license` as `dynamic` in `pyproject.toml` and provided it through `setup.py` (`license="Apache-2.0"`). This avoids the `setuptools` 83+ deprecation warning for `project.license` as a TOML table while still being valid for `setuptools>=61`.
- Lowered the build-system `setuptools` lower bound from `>=77.0.1` to `>=61` since the PEP 639 SPDX feature is no longer used.

## Verification

- `pip install .` succeeds with modern `pip`/setuptools build isolation.
- `pip install . --no-build-isolation` succeeds on fresh venvs with `setuptools` 59.6, 60, 61, 65, 75, 80, 82, and 83, with `Name: LogBar` and no license/UNKNOWN warnings.
- Local test suite passes: `157 passed, 6 skipped`.

Link to Devin session: https://app.devin.ai/sessions/fd150f4dd61f470e96ff670b2dfe7649
Requested by: @Qubitium