### PR TITLE
fix(tests): evaluate columns level-prefix budget inside redirect_stdout context

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -228,6 +228,9 @@ def test_columns_respects_available_width():
         buffer = io.StringIO()
         with redirect_stdout(buffer):
             cols.info.header()
+            # Evaluate the level-prefix budget inside the same stdout context
+            # used to render the header so the expected width matches the row.
+            expected = columns - (cols._get_level_max_length() + 1)
 
     cleaned = _clean(buffer.getvalue())
     header_lines = [line for line in cleaned.splitlines() if '|  c1' in line]
@@ -237,7 +240,6 @@ def test_columns_respects_available_width():
     row_segment = header_line[header_line.index('|'):]
     # The logger reserves one trailing space after the level prefix, so the
     # row budget is terminal width minus the prefix.
-    expected = columns - (cols._get_level_max_length() + 1)
     segment_len = len(row_segment)
     content_segment = row_segment[: row_segment.rfind('|') + 1]
     slot_widths = cols.widths


### PR DESCRIPTION
Moves the `expected` width calculation in `test_columns_respects_available_width` inside the `redirect_stdout` context so it uses the same backend state as the rendered header.

`cols._get_level_max_length()` resolves the current symbol/text prefix budget from `sys.stdout`. When the test ran in a real PTY terminal, the row was rendered while `stdout` was redirected to `StringIO` (text-mode prefix, width 5) but the expectation was computed after `stdout` reverted to the PTY (symbol-mode prefix, width 1). This caused `assert segment_len == expected` to fail with `114 == 118`. Evaluating `expected` inside the redirect removes the stdout-state race and keeps the test valid for both TTY and non-TTY runners.

Link to Devin session: https://app.devin.ai/sessions/190302adb5444c12ae67347f8b289ae1
Requested by: @Qubitium